### PR TITLE
docs: Remove type props from ToastContainer

### DIFF
--- a/src/BasicExample/Simple.js
+++ b/src/BasicExample/Simple.js
@@ -76,7 +76,6 @@ class Simple extends Component {
     const container = `
       <ToastContainer 
           position="${this.props.position}"
-          type="${this.props.type}"
           autoClose={${this.props.autoClose === false
             ? false
             : this.props.delay}}


### PR DESCRIPTION
The simple example generates code where ToastContainer has the type
prop, which doesn't really exist. This removes it from the generated
code.