### PR TITLE
Missing property in the type definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,12 @@ interface styleProps {
    * Default: 'only screen and (max-width : 480px)'
    */
   mobile?: string;
+  
+  /**
+   * Override the font-family style property.
+   * Default: 'sans-serif'
+   */
+  fontFamily?: string;
 
   /**
    * Set the z-index for the ToastContainer.


### PR DESCRIPTION
I found the `fontFamily` property is missing in the type definitions file. Now it's back.