### PR TITLE
Added option to manually set a toastId

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,9 +1020,12 @@ The **toastId** can be used to remove a toast programmatically or to check if th
     - `progressClassName`: same as ToastContainer
     - `draggable`: same as ToastContainer
     - `draggablePercent`: same as ToastContainer
+    - `toastId`: optional integer to manually set a toastId
     - `render`: string or React Element, only available when calling update
 
 :warning:️ *Toast options supersede ToastContainer props* :warning:
+
+:warning:️ *Manually setting a toastId can overwrite automatically generated toastIds* :warning:
 
 ```javascript
 const Img = ({ src }) => <div><img width={48} src={src} /></div>;

--- a/src/__tests__/toast.js
+++ b/src/__tests__/toast.js
@@ -38,6 +38,20 @@ describe('toastify', () => {
     expect(firstId).not.toEqual(secondId);
   });
 
+  it('Should use the provided toastId from options', () => {
+    const toastId = 11;
+    const id = toast('Hello', { toastId });
+
+    expect(id).toEqual(toastId);
+  });
+
+  it('Should not use the provided invalid toastId from options', () => {
+    const toastId = 'myId';
+    const id = toast('Hello', { toastId });
+
+    expect(id).not.toEqual(toastId);
+  });
+
   describe('onChange event', () => {
     it('Should be able to track when toast is added or removed', () => {
       mount(<ToastContainer />);

--- a/src/toast.js
+++ b/src/toast.js
@@ -10,7 +10,18 @@ const noop = () => false;
  * Merge provided options with the defaults settings and generate the toastId
  */
 function mergeOptions(options, type) {
-  return { ...options, type, toastId: ++toastId };
+  return { ...options, type, toastId: generateToastId(options) };
+}
+
+/**
+ * Generate the toastId either automatically or by provided toastId
+ */
+function generateToastId(options) {
+  if (options === Object(options) && options.toastId === parseInt(options.toastId, 10)) {
+    return options.toastId;
+  }
+
+  return ++toastId;
 }
 
 /**

--- a/src/toast.js
+++ b/src/toast.js
@@ -17,7 +17,10 @@ function mergeOptions(options, type) {
  * Generate the toastId either automatically or by provided toastId
  */
 function generateToastId(options) {
-  if (options === Object(options) && options.toastId === parseInt(options.toastId, 10)) {
+  const type = typeof options;
+  const isObject = options != null && (type === 'object' || type === 'function');
+
+  if (isObject && options.toastId === parseInt(options.toastId, 10)) {
     return options.toastId;
   }
 


### PR DESCRIPTION
This pull request adds a new option to allow a user to manually set the toastId of the toast they are creating.

In some situations a race condition can occur if multiple async requests are dispatched but are intended to create/update the same toast. Without being able to manually set the toastId, multiple competing requests can generate several toasts at the same time. By manually defining a toastId, we can always be sure to create and edit the same toast.