### PR TITLE
Revert "Scrict typings for toast's position and type"

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -129,7 +129,7 @@ interface ToastOptions extends CommonOptions {
   /**
    * Set a custom `toastId`
    */
-  toastId?: number|string;
+  toastId?: number | string;
 }
 
 interface UpdateOptions extends ToastOptions {
@@ -219,27 +219,27 @@ interface Toast {
     /**
      * Set notification type to `'info'`
      */
-    INFO: string;
+    INFO: 'info';
 
     /**
      * Set notification type to `'success'`
      */
-    SUCCESS: string;
+    SUCCESS: 'success';
 
     /**
      * Set notification type to `'warning'`
      */
-    WARNING: string;
+    WARNING: 'warning';
 
     /**
      * Set notification type to `'error'`
      */
-    ERROR: string;
+    ERROR: 'error';
 
     /**
      * Set notification type to `'default'`
      */
-    DEFAULT: string;
+    DEFAULT: 'default';
   };
 
   /**
@@ -249,36 +249,36 @@ interface Toast {
     /**
      * Set the position to `'top-left'`
      */
-    TOP_LEFT: string;
+    TOP_LEFT: 'top-left'
 
     /**
      * Set the position to `'top-right'`
      */
-    TOP_RIGHT: string;
+    TOP_RIGHT: 'top-right'
 
     /**
      * Set the position to `'top-center'`
      */
-    TOP_CENTER: string;
+    TOP_CENTER: 'top-center'
 
     /**
      * Set the position to `'bottom-left'`
      */
-    BOTTOM_LEFT: string;
+    BOTTOM_LEFT: 'bottom-left'
 
     /**
      * Set the position to `'bottom-right'`
      */
-    BOTTOM_RIGHT: string;
+    BOTTOM_RIGHT: 'bottom-right'
 
     /**
      * Set the position to `'bottom-center'`
      */
-    BOTTOM_CENTER: string;
+    BOTTOM_CENTER: 'bottom-center'
   };
 }
 
-export class ToastContainer extends React.Component<ToastContainerProps, any> {}
+export class ToastContainer extends React.Component<ToastContainerProps, any> { }
 
 /**
  * Helper to build custom entrance and exit transition

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,8 @@
 import * as React from 'react';
 
-export const enum ToastType {
-  INFO = 'info',
-  SUCCESS = 'success',
-  WARNING = 'warning',
-  ERROR = 'error',
-  DEFAULT = 'default'
-}
+type ToastType = 'info' | 'success' | 'warning' | 'error' | 'default';
 
-export const enum ToastPosition {
-  TOP_RIGHT = 'top-right',
-  TOP_CENTER = 'top-center',
-  TOP_LEFT = 'top-left',
-  BOTTOM_RIGHT = 'bottom-right',
-  BOTTOM_CENTER = 'bottom-center',
-  BOTTOM_LEFT = 'bottom-left'
-}
+type ToastPosition = 'top-right' | 'top-center' | 'top-left' | 'bottom-right' | 'bottom-center' | 'bottom-left';
 
 type ToastContent = React.ReactNode | { (): void };
 
@@ -232,27 +219,27 @@ interface Toast {
     /**
      * Set notification type to `'info'`
      */
-    INFO: ToastType.INFO;
+    INFO: string;
 
     /**
      * Set notification type to `'success'`
      */
-    SUCCESS: ToastType.SUCCESS;
+    SUCCESS: string;
 
     /**
      * Set notification type to `'warning'`
      */
-    WARNING: ToastType.WARNING;
+    WARNING: string;
 
     /**
      * Set notification type to `'error'`
      */
-    ERROR: ToastType.ERROR;
+    ERROR: string;
 
     /**
      * Set notification type to `'default'`
      */
-    DEFAULT: ToastType.DEFAULT;
+    DEFAULT: string;
   };
 
   /**
@@ -262,32 +249,32 @@ interface Toast {
     /**
      * Set the position to `'top-left'`
      */
-    TOP_LEFT: ToastPosition.TOP_LEFT;
+    TOP_LEFT: string;
 
     /**
      * Set the position to `'top-right'`
      */
-    TOP_RIGHT: ToastPosition.TOP_RIGHT;
+    TOP_RIGHT: string;
 
     /**
      * Set the position to `'top-center'`
      */
-    TOP_CENTER: ToastPosition.TOP_CENTER;
+    TOP_CENTER: string;
 
     /**
      * Set the position to `'bottom-left'`
      */
-    BOTTOM_LEFT: ToastPosition.BOTTOM_LEFT;
+    BOTTOM_LEFT: string;
 
     /**
      * Set the position to `'bottom-right'`
      */
-    BOTTOM_RIGHT: ToastPosition.BOTTOM_RIGHT;
+    BOTTOM_RIGHT: string;
 
     /**
      * Set the position to `'bottom-center'`
      */
-    BOTTOM_CENTER: ToastPosition.BOTTOM_CENTER;
+    BOTTOM_CENTER: string;
   };
 }
 


### PR DESCRIPTION
This reverts commit 1f338562941337ebebea71a2d33eac69d98cd240.

This caused a runtime error as the values of TypeScript enums are not available in the output JS. See [this blog post](https://lukasbehal.com/2017-05-22-enums-in-declaration-files/) and [StackOverflow](https://stackoverflow.com/a/38384445) question as references.

This will resolve #196.