### PR TITLE
When hover over close button the timer will not play

### DIFF
--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -218,15 +218,19 @@ class Toast extends Component {
     }
   };
 
-  onDragTransitionEnd = () => {
+  onDragTransitionEnd = e => {
     const { top, bottom, left, right } = this.ref.getBoundingClientRect();
+    const isCloseButtonTransition = e.target.classList.contains(
+      'Toastify__close-button'
+    );
 
     if (
-      this.props.pauseOnHover &&
-      this.drag.x >= left &&
-      this.drag.x <= right &&
-      this.drag.y >= top &&
-      this.drag.y <= bottom
+      (this.props.pauseOnHover &&
+        this.drag.x >= left &&
+        this.drag.x <= right &&
+        this.drag.y >= top &&
+        this.drag.y <= bottom) ||
+      isCloseButtonTransition
     ) {
       this.pauseToast();
     } else {


### PR DESCRIPTION
#237 

I'd prefer it if we can identify the transition target as the close button some other way than class name, but I can't think of anything. This works.