### PR TITLE
BEM block className prefix

### DIFF
--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -131,6 +131,7 @@ describe('ToastContainer', () => {
     expect(Object.keys(props.closeButton.props)).toMatchObject([
       'ariaLabel',
       'closeToast',
+      'prefixCls',
       'type'
     ]);
   });

--- a/src/__tests__/components/__snapshots__/Toast.js.snap
+++ b/src/__tests__/components/__snapshots__/Toast.js.snap
@@ -24,6 +24,7 @@ ShallowWrapper {
     pauseOnFocusLoss={true}
     pauseOnHover={true}
     position="top-right"
+    prefixCls="Toastify"
     progressClassName={null}
     progressStyle={null}
     role="alert"

--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function CloseButton({ closeToast, type, ariaLabel }) {
+function CloseButton({
+ closeToast,
+ type,
+ ariaLabel,
+ prefixCls = 'Toastify'
+}) {
   return (
     <button
-      className={`Toastify__close-button Toastify__close-button--${type}`}
+      className={`${prefixCls}__close-button ${prefixCls}__close-button--${type}`}
       type="button"
       onClick={closeToast}
       aria-label={ariaLabel}

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -12,7 +12,8 @@ function ProgressBar({
   hide,
   className,
   style: userStyle,
-  rtl
+  rtl,
+  prefixCls = 'Toastify'
 }) {
   const style = {
     ...userStyle,
@@ -22,10 +23,10 @@ function ProgressBar({
   };
 
   const classNames = cx(
-    'Toastify__progress-bar',
-    `Toastify__progress-bar--${type}`,
+    `${prefixCls}__progress-bar`,
+    `${prefixCls}__progress-bar--${type}`,
     {
-      'Toastify__progress-bar--rtl': rtl
+      [`${prefixCls}__progress-bar--rtl`]: rtl
     },
     className
   );

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -52,7 +52,8 @@ class Toast extends Component {
     ]),
     progressStyle: PropTypes.object,
     updateId: PropTypes.number,
-    ariaLabel: PropTypes.string
+    ariaLabel: PropTypes.string,
+    prefixCls: PropTypes.string
   };
 
   static defaultProps = {
@@ -64,7 +65,8 @@ class Toast extends Component {
     bodyClassName: null,
     progressClassName: null,
     updateId: null,
-    role: 'alert'
+    role: 'alert',
+    prefixCls: 'Toastify'
   };
 
   state = {
@@ -253,15 +255,16 @@ class Toast extends Component {
       progressStyle,
       updateId,
       role,
-      rtl
+      rtl,
+      prefixCls,
     } = this.props;
 
     const toastProps = {
       className: cx(
-        'Toastify__toast',
-        `Toastify__toast--${type}`,
+        `${prefixCls}__toast`,
+        `${prefixCls}__toast--${type}`,
         {
-          'Toastify__toast--rtl': rtl
+          [`${prefixCls}__toast--rtl`]: rtl
         },
         className
       )
@@ -295,7 +298,7 @@ class Toast extends Component {
         >
           <div
             {...this.props.in && { role: role }}
-            className={cx('Toastify__toast-body', bodyClassName)}
+            className={cx(`${prefixCls}__toast-body`, bodyClassName)}
           >
             {children}
           </div>
@@ -311,6 +314,7 @@ class Toast extends Component {
               type={type}
               style={progressStyle}
               className={progressClassName}
+              prefixCls={prefixCls}
             />
           )}
         </div>

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -108,7 +108,12 @@ class ToastContainer extends Component {
     /**
      * Pause the toast on focus loss
      */
-    pauseOnFocusLoss: PropTypes.bool
+    pauseOnFocusLoss: PropTypes.bool,
+
+    /**
+     * Add a custom prefix to toast block. Replaces BEM block name Toastify when this is set
+     */
+    prefixCls: PropTypes.string
   };
 
   static defaultProps = {
@@ -129,7 +134,8 @@ class ToastContainer extends Component {
     toastClassName: null,
     bodyClassName: null,
     progressClassName: null,
-    progressStyle: null
+    progressStyle: null,
+    prefixCls: 'Toastify',
   };
 
   /**
@@ -181,7 +187,8 @@ class ToastContainer extends Component {
   }
 
   makeCloseButton(toastClose, toastId, type) {
-    let closeButton = this.props.closeButton;
+    const { prefixCls } = this.props
+    let { closeButton } = this.props;
 
     if (isValidElement(toastClose) || toastClose === false) {
       closeButton = toastClose;
@@ -191,6 +198,7 @@ class ToastContainer extends Component {
       ? false
       : cloneElement(closeButton, {
           closeToast: () => this.removeToast(toastId),
+          prefixCls,
           type: type
         });
   }
@@ -322,9 +330,11 @@ class ToastContainer extends Component {
   }
 
   makeToast(content, options) {
+    const { prefixCls } = this.props
     return (
       <Toast
         {...options}
+        prefixCls={prefixCls}
         isDocumentHidden={this.state.isDocumentHidden}
         key={`toast-${options.id}`}
       >
@@ -339,7 +349,7 @@ class ToastContainer extends Component {
 
   renderToast() {
     const toastToRender = {};
-    const { className, style, newestOnTop } = this.props;
+    const { className, style, newestOnTop, prefixCls } = this.props;
     const collection = newestOnTop
       ? Object.keys(this.collection).reverse()
       : Object.keys(this.collection);
@@ -363,9 +373,9 @@ class ToastContainer extends Component {
         toastToRender[position][0] === null;
       const props = {
         className: cx(
-          'Toastify__toast-container',
-          `Toastify__toast-container--${position}`,
-          { 'Toastify__toast-container--rtl': this.props.rtl },
+          `${prefixCls}__toast-container`,
+          `${prefixCls}__toast-container--${position}`,
+          {[`${prefixCls}__toast-container--rtl`]: this.props.rtl },
           this.parseClassName(className)
         ),
         style: disablePointer
@@ -382,7 +392,8 @@ class ToastContainer extends Component {
   }
 
   render() {
-    return <div className="Toastify">{this.renderToast()}</div>;
+    const { prefixCls } = this.props
+    return <div className={prefixCls}>{this.renderToast()}</div>;
   }
 }
 


### PR DESCRIPTION
This allows custom block name class to Toasts:

without setting prefixCls:
```html
<div class="Toastify">
    <div class="Toastify__toast-container Toastify__toast-container--top-right">
        <div class="Toastify__toast Toastify__toast--default" style="">
            <div role="alert" class="Toastify__toast-body">🦄 Wow so easy !</div>
            <button class="Toastify__close-button Toastify__close-button--default" type="button" aria-label="close">✖
            </button>
        </div>
    </div>
</div>
```

with prefixCls = 'Custom-Toastify'
```html
<div class="Custom-Toastify">
  <div class="Custom-Toastify__toast-container Custom-Toastify__toast-container--top-right">
    <div class="Custom-Toastify__toast Custom-Toastify__toast--default" style="">
      <div role="alert" class="Custom-Toastify__toast-body">🦄 Wow so easy !</div>
      <button class="Custom-Toastify__close-button Custom-Toastify__close-button--default" type="button"
              aria-label="close">✖
      </button>
      <div class="Custom-Toastify__progress-bar Custom-Toastify__progress-bar--default"
           style="animation-duration: 5000ms; animation-play-state: running; opacity: 1;"></div>
    </div>
  </div>
</div>
```

