### PR TITLE
#247 Allow closeButton to be a function

### DIFF
--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -183,16 +183,22 @@ class ToastContainer extends Component {
   makeCloseButton(toastClose, toastId, type) {
     let closeButton = this.props.closeButton;
 
+    const closeButtonProps = {
+      closeToast: () => this.removeToast(toastId),
+        type: type
+    }
+
+    if (typeof closeButton === 'function') {
+      return closeButton(closeButtonProps)
+    }
+
     if (isValidElement(toastClose) || toastClose === false) {
       closeButton = toastClose;
     }
 
     return closeButton === false
       ? false
-      : cloneElement(closeButton, {
-          closeToast: () => this.removeToast(toastId),
-          type: type
-        });
+      : cloneElement(closeButton, closeButtonProps);
   }
 
   getAutoCloseDelay(toastAutoClose) {

--- a/src/utils/propValidator.js
+++ b/src/utils/propValidator.js
@@ -35,8 +35,7 @@ export const falseOrDelay = withRequired((props, propName, componentName) => {
 
 export const falseOrElement = withRequired((props, propName, componentName) => {
   const prop = props[propName];
-
-  if (prop !== false && !isValidElement(prop)) {
+  if (prop !== false && !isValidElement(prop) && typeof prop !== 'function') {
     return new Error(`${componentName} expect ${propName} 
       to be a valid react element or equal to false. ${prop} given.`);
   }


### PR DESCRIPTION
Allowing a function as a closeButton referenced in #247

```jsx 
...
closeButton={({ closeButton }) => <button onClick={closeButton}>custom</button>}
...
```