### PR TITLE
Fix for Toast Position, shouldn't be both const and enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export const enum ToastType {
+export enum ToastType {
   INFO = 'info',
   SUCCESS = 'success',
   WARNING = 'warning',
@@ -8,7 +8,7 @@ export const enum ToastType {
   DEFAULT = 'default'
 }
 
-export const enum ToastPosition {
+export enum ToastPosition {
   TOP_RIGHT = 'top-right',
   TOP_CENTER = 'top-center',
   TOP_LEFT = 'top-left',


### PR DESCRIPTION
There should either be an enum or a const, they don't work together.
This causes errors when using Typescript and importing the types