### PR TITLE
#285 Add a section about rendering ToastContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ The toasts inherit ToastContainer's props. **Props defined on toast supersede To
   }
 ```
 
+Remember to render the `ToastContainer` *once* in your application tree. 
+If you can't figure out where to put it, rendering it in the application root would be the best bet. 
+
 ### Positioning toast
 
 By default, all the toasts will be positionned on the top right of your browser. If a position is set on a toast, the one defined on ToastContainer will be replaced.


### PR DESCRIPTION
Added lines to the docs: 

> Remember to render the `ToastContainer` *once* in your application tree. 
> If you can't figure out where to put it, rendering it in the application root would be the best bet. 