### PR TITLE
Display default CloseButton when set closeButton option to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,7 @@ On mobile the toast will take all the available width.
 |-------------------------|------------------------|-----------|-----------------------------------------------------------------------------------------------------|
 | position                | string                 | top-right | One of top-right, top-center, top-left, bottom-right, bottom-center, bottom-left                    |
 | autoClose               | false or number        | 5000      | Delay in ms to close the toast. If set to false, the notification need to be closed manualy         |
-| closeButton             | React Element or false | -         | A React Component to replace the default close button or `false` to hide the button                 |
+| closeButton             | React Element or bool  | -         | A React Component to replace the default close button or `false` to hide the button, set `true` to use the default CloseButton element                 |
 | transition              | function               | -         | A reference to a valid react-transition-group/Transition component                                  |
 | hideProgressBar         | bool                   | false     | Display or not the progress bar below the toast(remaining time)                                     |
 | pauseOnHover            | bool                   | true      | Keep the timer running or not on hover                                                              |
@@ -1100,7 +1100,7 @@ On mobile the toast will take all the available width.
 | toastClassName          | string\|object         | -         | Add optional classes to the toast                                                                   |
 | bodyClassName           | string\|object         | -         | Add optional classes to the toast body                                                              |
 | progressClassName       | string\|object         | -         | Add optional classes to the progress bar                                                            |
-| progressStyle           | object                 | -         | Add optional inline style to the progress bar                                                            |
+| progressStyle           | object                 | -         | Add optional inline style to the progress bar                                                       |
 | draggable               | bool                   | true      | Allow toast to be draggable                                                                         |
 | draggablePercent        | number                 | 80        | The percentage of the toast's width it takes for a drag to dismiss a toast(value between 0 and 100) |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ interface CommonOptions {
    * Pass a custom close button.
    * To remove the close button pass `false`
    */
-  closeButton?: React.ReactNode | false;
+  closeButton?: React.ReactNode | boolean;
 
   /**
    * An optional css class to set for the progress bar.

--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -150,6 +150,20 @@ describe('ToastContainer', () => {
     expect(component.html()).not.toMatch(/toastify__close/);
   });
 
+  it('Should use default CloseButton when toast option set to true and ToastContainer options set to false', () => {
+    // set closeButton to false to remove it by default
+    let component = mount(<ToastContainer closeButton={false} />);
+    toast('hello');
+    jest.runAllTimers();
+    // ensure that close button is NOT present by default
+    expect(component.html()).not.toMatch(/✖/);
+    
+    toast('hello', { closeButton: true });
+    jest.runAllTimers();
+    // now the close butotn should be here
+    expect(component.html()).toMatch(/✖/);
+  });
+
   it('Should merge className and style', () => {
     const component = mount(
       <ToastContainer className="foo" style={{ background: 'red' }} />

--- a/src/__tests__/components/__snapshots__/ProgressBar.js.snap
+++ b/src/__tests__/components/__snapshots__/ProgressBar.js.snap
@@ -25,8 +25,10 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
+    "simulateError": [Function],
     "simulateEvent": [Function],
     "unmount": [Function],
   },
@@ -92,9 +94,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,
@@ -104,8 +110,6 @@ ShallowWrapper {
         },
       },
     },
-    "attachTo": undefined,
-    "hydrateIn": undefined,
   },
 }
 `;
@@ -135,8 +139,10 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
+    "simulateError": [Function],
     "simulateEvent": [Function],
     "unmount": [Function],
   },
@@ -202,9 +208,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,
@@ -214,8 +224,6 @@ ShallowWrapper {
         },
       },
     },
-    "attachTo": undefined,
-    "hydrateIn": undefined,
   },
 }
 `;
@@ -247,8 +255,10 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
+    "simulateError": [Function],
     "simulateEvent": [Function],
     "unmount": [Function],
   },
@@ -294,9 +304,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,
@@ -306,8 +320,6 @@ ShallowWrapper {
         },
       },
     },
-    "attachTo": undefined,
-    "hydrateIn": undefined,
   },
 }
 `;

--- a/src/__tests__/components/__snapshots__/Toast.js.snap
+++ b/src/__tests__/components/__snapshots__/Toast.js.snap
@@ -38,8 +38,10 @@ ShallowWrapper {
   </Toast>,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
+    "simulateError": [Function],
     "simulateEvent": [Function],
     "unmount": [Function],
   },
@@ -219,9 +221,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,
@@ -231,8 +237,6 @@ ShallowWrapper {
         },
       },
     },
-    "attachTo": undefined,
-    "hydrateIn": undefined,
   },
 }
 `;

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -26,7 +26,7 @@ const noop = () => {};
 
 class Toast extends Component {
   static propTypes = {
-    closeButton: falseOrElement.isRequired,
+    closeButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]).isRequired,
     autoClose: falseOrDelay.isRequired,
     children: PropTypes.node.isRequired,
     closeToast: PropTypes.func.isRequired,

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -187,6 +187,8 @@ class ToastContainer extends Component {
 
     if (isValidElement(toastClose) || toastClose === false) {
       closeButton = toastClose;
+    } else if(toastClose === true) {
+      closeButton = <CloseButton />
     }
 
     return closeButton === false


### PR DESCRIPTION
Added new feature suggested on #310 to display the default `<CloseButton />` element when set `closeButton={true}` on toast options which will supersede the same option on **ToastContainer** when `<ToastContainer closeButton={false} />`.

I also added a new test to test this new feature and updated the readme.