### PR TITLE
Display default CloseButton when closeButton option set to true 

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,14 @@ Sometimes you don't want to display a close button. It can be removed globally o
     })
 ```
 
+-- if you removed it globally, you can display the default Button per toast (or you can set your custom button)
+
+```js
+    toast("hello", {
+      closeButton: true // or <FontAwesomeCloseButton />
+    })
+```
+
 ### Add an undo option to a toast like google drive
 
 See it in action:
@@ -1121,7 +1129,7 @@ The **toastId** can be used to remove a toast programmatically or to check if th
     - `onOpen`: Called inside componentDidMount
     - `onClose`: Called inside componentWillUnmount
     - `autoClose`: same as ToastContainer.
-    - `closeButton`: same as ToastContainer.
+    - `closeButton`: `false` to disable, a `React Component` to replace or `true` to display the default button.
     - `transition`: same as ToastContainer.
     - `closeOnClick`: same as ToastContainer.
     - `hideProgressBar`: same as ToastContainer.

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ interface CommonOptions {
    * Pass a custom close button.
    * To remove the close button pass `false`
    */
-  closeButton?: React.ReactNode | false;
+  closeButton?: React.ReactNode | boolean;
 
   /**
    * An optional css class to set for the progress bar.

--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -150,6 +150,19 @@ describe('ToastContainer', () => {
     expect(component.html()).not.toMatch(/toastify__close/);
   });
 
+  it('Should use default CloseButton when toast option set to true and ToastContainer options is false', () => {
+    // set closeButton to false to remove it by default
+    let component = mount(<ToastContainer closeButton={false} />);
+    toast('hello');
+    jest.runAllTimers();
+    // ensure that close button is NOT present by default
+    expect(component.html()).not.toMatch(/✖/);
+    toast('hello', { closeButton: true });
+    jest.runAllTimers();
+    // now the close button should be present
+    expect(component.html()).toMatch(/✖/);
+  });
+
   it('Should merge className and style', () => {
     const component = mount(
       <ToastContainer className="foo" style={{ background: 'red' }} />

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -26,7 +26,8 @@ const noop = () => {};
 
 class Toast extends Component {
   static propTypes = {
-    closeButton: falseOrElement.isRequired,
+    closeButton: PropTypes.oneOfType([PropTypes.node, PropTypes.node])
+      .isRequired,
     autoClose: falseOrDelay.isRequired,
     children: PropTypes.node.isRequired,
     closeToast: PropTypes.func.isRequired,

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -4,11 +4,7 @@ import cx from 'classnames';
 
 import ProgressBar from './ProgressBar';
 import { POSITION, TYPE } from './../utils/constant';
-import {
-  falseOrElement,
-  falseOrDelay,
-  objectValues
-} from './../utils/propValidator';
+import { falseOrDelay, objectValues } from './../utils/propValidator';
 
 function getX(e) {
   return e.targetTouches && e.targetTouches.length >= 1

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -187,6 +187,8 @@ class ToastContainer extends Component {
 
     if (isValidElement(toastClose) || toastClose === false) {
       closeButton = toastClose;
+    } else if (toastClose === true) {
+      closeButton = <CloseButton />;
     }
 
     return closeButton === false


### PR DESCRIPTION
Added new feature suggested on #310 to display the default `<CloseButton />` element when set `closeButton={true}` on toast options which will supersede the same option on **ToastContainer** when `<ToastContainer closeButton={false} />`.

I also added a new test to test this new feature and updated the readme.