### PR TITLE
Remove hard-coded default toast text color

### DIFF
--- a/scss/_toast.scss
+++ b/scss/_toast.scss
@@ -18,7 +18,7 @@
     }
     &--default {
         background: $rt-color-default;
-        color: #aaa;
+        color: $rt-text-color-default;
     }
     &--info {
         background: $rt-color-info;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -4,12 +4,13 @@ $rt-toast-background: #ffffff !default;
 $rt-toast-min-height: 64px !default;
 $rt-toast-max-height: 800px !default;
 
-
 $rt-color-default: #fff !default;
 $rt-color-info: #3498db !default;
 $rt-color-success: #07bc0c !default;
 $rt-color-warning: #f1c40f !default;
 $rt-color-error: #e74c3c !default;
+
+$rt-text-color-default: #aaa !default;
 
 $rt-color-progress-default: linear-gradient(to right, #4cd964, #5ac8fa, #007aff, #34aadc, #5856d6, #ff2d55) !default;
 


### PR DESCRIPTION
Hi,

I noticed the default toast text color was hard-coded to `#aaa` and thus it was not possible to edit the default value from the SCSS. I introduced a new variable `$rt-text-color-default` based on the other existing variables.

Let me know if that sounds good to you or anything else.