### PR TITLE
feat: allow user to override default role

### DIFF
--- a/src/__tests__/components/Toast.js
+++ b/src/__tests__/components/Toast.js
@@ -199,6 +199,20 @@ describe('Toast', () => {
     expect(component.html()).toMatch(/transform:(\s)?scaleX\(0.3\)/);
   });
 
+  it('Should add the role prop to the toast body', () => {
+    const component = shallow(
+      <Toast
+        {...REQUIRED_PROPS}
+        role="status"
+      >
+        FooBar
+      </Toast>
+    );
+    expect(component.find(".Toastify__toast-body").prop("role")).toEqual(
+      "status"
+    );
+  })
+
   describe('Drag event', () => {
     it('Should handle drag start on mousedown', () => {
       const events = {};

--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -42,7 +42,8 @@ describe('ToastContainer', () => {
     -position
     -pauseOnHover
     -transition
-    -closeToast`, () => {
+    -closeToast
+    -role`, () => {
     const component = mount(<ToastContainer />);
     // Create a toast
     toast('coucou');
@@ -55,7 +56,8 @@ describe('ToastContainer', () => {
       'position',
       'closeToast',
       'transition',
-      'pauseOnHover'
+      'pauseOnHover',
+      'role'
     ].forEach(key => expect(hasProp(props, key)).toBeTruthy());
   });
 
@@ -125,7 +127,8 @@ describe('ToastContainer', () => {
       autoClose: false,
       hideProgressBar: true,
       position: 'top-left',
-      closeButton: <CloseBtn />
+      closeButton: <CloseBtn />,
+      role: "status"
     };
 
     toast('hello', desiredProps);

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -57,7 +57,8 @@ class Toast extends Component {
     isProgressDone: PropTypes.bool,
     updateId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     ariaLabel: PropTypes.string,
-    containerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    containerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    role: PropTypes.string
   };
 
   static defaultProps = {
@@ -69,7 +70,6 @@ class Toast extends Component {
     bodyClassName: null,
     progressClassName: null,
     updateId: null,
-    role: 'alert'
   };
 
   state = {

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -308,7 +308,8 @@ class ToastContainer extends Component {
           ? options.hideProgressBar
           : this.props.hideProgressBar,
       progress: parseFloat(options.progress),
-      isProgressDone: options.isProgressDone
+      isProgressDone: options.isProgressDone,
+      role: options.role
     };
 
     typeof options.onOpen === 'function' &&

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -117,7 +117,12 @@ class ToastContainer extends Component {
     /**
      * Set id to handle multiple container
      */
-    containerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    containerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * Set role attribute for the toast body 
+     */
+    role: PropTypes.string
   };
 
   static defaultProps = {
@@ -138,7 +143,8 @@ class ToastContainer extends Component {
     toastClassName: null,
     bodyClassName: null,
     progressClassName: null,
-    progressStyle: null
+    progressStyle: null,
+    role: "alert"
   };
 
   /**
@@ -309,7 +315,10 @@ class ToastContainer extends Component {
           : this.props.hideProgressBar,
       progress: parseFloat(options.progress),
       isProgressDone: options.isProgressDone,
-      role: options.role
+      role: 
+        typeof options.role === 'string'
+          ? options.role
+          : this.props.role
     };
 
     typeof options.onOpen === 'function' &&


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 



**Description**
Currently the toast body contains a default `role="alert"`, which is intended for very important messages that can interrupt the users. However, in many situations you do not need to interrupt the user. For such cases, `role="status"` can be used instead.

This PR allows the user to override the default role via options.