### PR TITLE
Options parameter of toast.update made optional

### DIFF
--- a/src/__tests__/toast.js
+++ b/src/__tests__/toast.js
@@ -165,6 +165,9 @@ describe('toastify', () => {
       });
       jest.runAllTimers();
       expect(component.html()).toMatch(/hello/);
+      toast.update(id);
+      jest.runAllTimers();
+      expect(component.html()).toMatch(/hello/);
     });
 
     it('Should update a toast only if it exist and if the container is mounted', () => {

--- a/src/toast.js
+++ b/src/toast.js
@@ -94,7 +94,7 @@ toast.dismiss = (id = null) => container && eventManager.emit(ACTION.CLEAR, id);
  */
 toast.isActive = NOOP;
 
-toast.update = (toastId, options) => {
+toast.update = (toastId, options = {}) => {
   // if you call toast and toast.update directly nothing will be displayed
   // this is why I defered the update
   setTimeout(() => {


### PR DESCRIPTION
<!--
**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 
-->

## Status
`Ready for Review`

## Description
Hello!

First of all, thanks for this amazing tool! So well thought out and extremely robust!

This simple PR is to make the `options` parameter of `toast.update` optional. For the most part, I'm sure we would want to update the content or other configurations, but I noticed for my specific use case, I wanted to extend the autoClose delay of a specific toast message instead of adding more toasts of the same content. But it seems like the `options` parameter is required, because the code assumes it's passed in when accessing `toastId`, and I was seeing errors in my unit tests when I didn't pass it in.

Maybe there is a better way to do this instead of just keeping the empty object
```js
toast.update(toastId, {})
```

Thanks!
Parth