### PR TITLE
Allow updating toasts when using multi containers

### DIFF
--- a/src/__tests__/toast.js
+++ b/src/__tests__/toast.js
@@ -196,6 +196,34 @@ describe('toastify', () => {
       expect(toast.isActive(id)).toBe(false);
       expect(toast.isActive(updateId)).toBe(true);
     });
+
+    it('Should be able to update a toast even when using multi containers', () => {
+      const component = mount(
+        <>
+          <ToastContainer containerId='first' enableMultiContainer />
+          <ToastContainer containerId='second' enableMultiContainer />
+        </>
+      );
+
+      const firstId = toast('hello first', { containerId: 'first' });
+      const secondId = toast('hello second', { containerId: 'second' });
+      jest.runAllTimers();
+
+      toast.update(firstId, {
+        render: 'updated first',
+        containerId: 'first'
+      });
+
+      toast.update(secondId, {
+        render: 'updated second',
+        containerId: 'second'
+      });
+
+      jest.runAllTimers();
+
+      expect(component.first().html()).toMatch(/updated first/);
+      expect(component.at(1).html()).toMatch(/updated second/);
+    });
   });
 
   describe('isActive function', () => {

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -181,7 +181,7 @@ class ToastContainer extends Component {
     eventManager
       .off(ACTION.SHOW)
       .off(ACTION.CLEAR)
-      .emit(ACTION.WILL_UNMOUNT);
+      .emit(ACTION.WILL_UNMOUNT, this);
   }
 
   isToastActive = id => this.state.toast.indexOf(id) !== -1;


### PR DESCRIPTION
Closes #345 **Update content not working when using multi container**

`toast.js` previously only tracked the last declared `ToastContainer` and this is why it wasn't possible to update toasts fired from inside containers that weren't the last ones.

To solve this I begin tracking all containers inside `toast.js` and using the `containerId` in the options to inform in which containerId is the toast located.

Another possibility would be to care only about the `toastId`. I think we could discuss this here. After we decide which route to take, I can also use this PR to update the docs accordingly.

