### PR TITLE
Ensure only one container is mounted when using lazy mounting

### DIFF
--- a/src/__tests__/toast.js
+++ b/src/__tests__/toast.js
@@ -40,6 +40,17 @@ describe('toastify', () => {
     unmountLazyContainer();
   });
 
+  it('Should mount only one ToastContainer when using lazy container', () => {
+    ensureLazyContainerIsNotMounted();
+    toast.configure();
+    toast('hello');
+    toast('hello');
+    jest.runAllTimers();
+
+    expect(document.querySelectorAll(containerClass)).toHaveLength(1);
+    unmountLazyContainer();
+  });
+
   it("Should be possible to configure the ToastContainer even when it's lazy mounted", () => {
     ensureLazyContainerIsNotMounted();
     toast.configure({

--- a/src/toast.js
+++ b/src/toast.js
@@ -51,6 +51,7 @@ function dispatchToast(content, options) {
   } else {
     queue.push({ action: ACTION.SHOW, content, options });
     if (lazy && canUseDom) {
+      lazy = false;
       containerDomNode = document.createElement('div');
       document.body.appendChild(containerDomNode);
       render(<ToastContainer {...containerConfig} />, containerDomNode);


### PR DESCRIPTION
Closes #363 **toast.configure, multiple containers created**

I did this in the most simple way possible.
Also, we could do another suggestion from the issue that would be to create a flag `isContainerMounted`. But I don't think it would be good to have another multable flag floating around, really... So this is why I used the existing one.