### PR TITLE
Add note on behavior of dismiss() when delaying notification appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,8 @@ toast('Show now');
 toast('Show after 1sec', { delay: 1000 })
 ```
 
+_Note: [toast.dismiss()](#remove-a-toast-programmatically) has no effect if called during the delay before a given toast appears._
+
 ### Use a controlled progress bar
 
 Imagine you want to see the progress of a file upload. The example below feature axios, but it works with anything!


### PR DESCRIPTION
Per #371 you cannot dismiss a delayed notification before it appears. This PR adds a note to the docs for *Delay notification appearance* to make that clear.
