### PR TITLE
Fix use closeButton from props when toastClose is true

### DIFF
--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -214,6 +214,23 @@ describe('ToastContainer', () => {
     expect(component.html()).toMatch(/✖/);
   });
 
+  it('Should use custom CloseButton when toast option set to true and ToastContainer options is custom', () => {
+    // set closeButton to false to remove it by default
+    const CloseBtn = () => <div>CUSTOM_BUTTON</div>;
+    let component = mount(<ToastContainer closeButton={<CloseBtn />} />);
+    toast('hello');
+    jest.runAllTimers();
+
+    // ensure that close button is NOT present by default
+    expect(component.html()).toMatch(/CUSTOM_BUTTON/);
+    toast('hello', { closeButton: true });
+    jest.runAllTimers();
+
+    // now the close button should be present
+    expect(component.html()).toMatch(/CUSTOM_BUTTON/);
+    expect(component.html()).not.toMatch(/✖/);
+  });
+
   it('Should merge className and style', () => {
     const component = mount(
       <ToastContainer className="foo" style={{ background: 'red' }} />

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -210,7 +210,13 @@ class ToastContainer extends Component {
     if (isValidElement(toastClose) || toastClose === false) {
       closeButton = toastClose;
     } else if (toastClose === true) {
-      closeButton = <CloseButton />;
+      closeButton =
+        this.props.closeButton &&
+        typeof this.props.closeButton !== 'boolean' ? (
+          this.props.closeButton
+        ) : (
+          <CloseButton />
+        );
     }
 
     return closeButton === false


### PR DESCRIPTION
see https://github.com/fkhadra/react-toastify/pull/313#issuecomment-513437356

that change had made it a lot harder to use the default button from the props. This change is there to make it easy to create toast using the button defined in the container. If people want the default button they can easily import it from the callspot.

