### PR TITLE
feat: Add RT_Namespace support for customize css selectors namespace

### DIFF
--- a/src/__tests__/components/Toast.js
+++ b/src/__tests__/components/Toast.js
@@ -6,6 +6,7 @@ import Toast from './../../components/Toast';
 import ToastContainer from './../../components/ToastContainer';
 import CloseButton from './../../components/CloseButton';
 import ProgressBar from './../../components/ProgressBar';
+import {RT_NAMESPACE} from "../../utils/constant";
 
 const REQUIRED_PROPS = {
   ...ToastContainer.defaultProps,
@@ -216,7 +217,7 @@ describe('Toast', () => {
     component.setProps({ progress: 1 });
     expect(component.html()).toMatch(/transform:(\s)?scaleX\(1\)/);
     component
-      .find('.Toastify__progress-bar--controlled')
+      .find(`.${RT_NAMESPACE}__progress-bar--controlled`)
       .simulate('transitionEnd');
     expect(closeToast).toHaveBeenCalled();
   });
@@ -227,7 +228,7 @@ describe('Toast', () => {
         FooBar
       </Toast>
     );
-    expect(component.find('.Toastify__toast-body').prop('role')).toEqual(
+    expect(component.find(`.${RT_NAMESPACE}__toast-body`).prop('role')).toEqual(
       'status'
     );
   });

--- a/src/__tests__/toast.js
+++ b/src/__tests__/toast.js
@@ -5,11 +5,11 @@ import { mount } from 'enzyme';
 import ToastContainer from './../components/ToastContainer';
 import toast from './../toast';
 import eventManager from './../utils/eventManager';
-import { ACTION, TYPE } from './../utils/constant';
+import { ACTION, TYPE, RT_NAMESPACE } from './../utils/constant';
 
 jest.useFakeTimers();
 
-const containerClass = '.Toastify__toast-container';
+const containerClass = `.${RT_NAMESPACE}__toast-container`;
 
 // Clear all previous event to avoid any clash between tests
 beforeEach(() => {
@@ -61,7 +61,7 @@ describe('toastify', () => {
     jest.runAllTimers();
 
     expect(document.querySelector(containerClass)).not.toBe(null);
-    expect(document.querySelector('.Toastify__toast-container--rtl')).not.toBe(
+    expect(document.querySelector(`.${RT_NAMESPACE}__toast-container--rtl`)).not.toBe(
       null
     );
     unmountLazyContainer();

--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {RT_NAMESPACE} from "../utils/constant";
 
 function CloseButton({ closeToast, type, ariaLabel }) {
   return (
     <button
-      className={`Toastify__close-button Toastify__close-button--${type}`}
+      className={`${RT_NAMESPACE}__close-button ${RT_NAMESPACE}__close-button--${type}`}
       type="button"
       onClick={e => {
         e.stopPropagation();

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-import { TYPE } from './../utils/constant';
+import { TYPE, RT_NAMESPACE } from './../utils/constant';
 import { falseOrDelay } from '../utils/propValidator';
 
 function ProgressBar({
@@ -26,13 +26,13 @@ function ProgressBar({
   };
 
   const classNames = cx(
-    'Toastify__progress-bar',
+    `${RT_NAMESPACE}__progress-bar`,
     controlledProgress
-      ? 'Toastify__progress-bar--controlled'
-      : 'Toastify__progress-bar--animated',
-    `Toastify__progress-bar--${type}`,
+      ? `${RT_NAMESPACE}__progress-bar--controlled`
+      : `${RT_NAMESPACE}__progress-bar--animated`,
+    `${RT_NAMESPACE}__progress-bar--${type}`,
     {
-      'Toastify__progress-bar--rtl': rtl
+      [`${RT_NAMESPACE}__progress-bar--rtl`]: rtl
     },
     className
   );

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import ProgressBar from './ProgressBar';
-import { POSITION, TYPE, NOOP } from './../utils/constant';
+import { POSITION, TYPE, NOOP, RT_NAMESPACE } from './../utils/constant';
 import {
   falseOrDelay,
   objectValues,
@@ -292,10 +292,10 @@ class Toast extends Component {
 
     const toastProps = {
       className: cx(
-        'Toastify__toast',
-        `Toastify__toast--${type}`,
+        `${RT_NAMESPACE}__toast`,
+        `${RT_NAMESPACE}__toast--${type}`,
         {
-          'Toastify__toast--rtl': rtl
+          [`${RT_NAMESPACE}__toast--rtl`]: rtl
         },
         className
       )
@@ -335,7 +335,7 @@ class Toast extends Component {
         >
           <div
             {...(this.props.in && { role: role })}
-            className={cx('Toastify__toast-body', bodyClassName)}
+            className={cx(`${RT_NAMESPACE}__toast-body`, bodyClassName)}
           >
             {children}
           </div>

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -13,6 +13,7 @@ import {
   isValidDelay,
   objectValues
 } from './../utils/propValidator';
+import {RT_NAMESPACE} from "./../utils/constant";
 
 class ToastContainer extends Component {
   static propTypes = {
@@ -418,9 +419,9 @@ class ToastContainer extends Component {
         toastToRender[position][0] === null;
       const props = {
         className: cx(
-          'Toastify__toast-container',
-          `Toastify__toast-container--${position}`,
-          { 'Toastify__toast-container--rtl': this.props.rtl },
+          `${RT_NAMESPACE}__toast-container`,
+          `${RT_NAMESPACE}__toast-container--${position}`,
+          { [`${RT_NAMESPACE}__toast-container--rtl`]: this.props.rtl },
           this.parseClassName(className)
         ),
         style: disablePointer
@@ -437,7 +438,7 @@ class ToastContainer extends Component {
   }
 
   render() {
-    return <div className="Toastify">{this.renderToast()}</div>;
+    return <div className={`${RT_NAMESPACE}`}>{this.renderToast()}</div>;
   }
 }
 

--- a/src/components/Transitions.js
+++ b/src/components/Transitions.js
@@ -1,26 +1,27 @@
 import cssTransition from './../utils/cssTransition';
+import {RT_NAMESPACE} from './../utils/constant';
 
 const Bounce = cssTransition({
-  enter: 'Toastify__bounce-enter',
-  exit: 'Toastify__bounce-exit',
+  enter: `${RT_NAMESPACE}__bounce-enter`,
+  exit: `${RT_NAMESPACE}__bounce-exit`,
   appendPosition: true
 });
 
 const Slide = cssTransition({
-  enter: 'Toastify__slide-enter',
-  exit: 'Toastify__slide-exit',
+  enter: `${RT_NAMESPACE}__slide-enter`,
+  exit: `${RT_NAMESPACE}__slide-exit`,
   duration: [450, 750],
   appendPosition: true
 });
 
 const Zoom = cssTransition({
-  enter: 'Toastify__zoom-enter',
-  exit: 'Toastify__zoom-exit'
+  enter: `${RT_NAMESPACE}__zoom-enter`,
+  exit: `${RT_NAMESPACE}__zoom-exit`
 });
 
 const Flip = cssTransition({
-  enter: 'Toastify__flip-enter',
-  exit: 'Toastify__flip-exit'
+  enter: `${RT_NAMESPACE}__flip-enter`,
+  exit: `${RT_NAMESPACE}__flip-exit`
 });
 
 export { Bounce, Slide, Zoom, Flip };

--- a/src/utils/constant.js
+++ b/src/utils/constant.js
@@ -23,3 +23,5 @@ export const ACTION = {
 };
 
 export const NOOP = () => {};
+
+export const RT_NAMESPACE = 'Toastify';


### PR DESCRIPTION
since there was a variable in `scss` variables file which can be used for defining a custom namespace for selectors I add support changing namespace inside JS files.
Add RT_NAMESSPACE constant inside the constant file for customizing css selector namespace.
