### PR TITLE
Adds missing commas, font stack to playground sample

### DIFF
--- a/playground/components/ToastCode.js
+++ b/playground/components/ToastCode.js
@@ -36,32 +36,32 @@ const ToastCode = ({
       </div>
       <div>
         <span className="code__props">position</span>
-        {`: "${position}"`}
+        {`: "${position}"`},
       </div>
       <div>
         <span className="code__props">autoClose</span>
-        {`: ${disableAutoClose ? false : autoClose}`}
+        {`: ${disableAutoClose ? false : autoClose}`},
       </div>
       <div>
         <span className="code__props">hideProgressBar</span>
-        {`: ${hideProgressBar ? 'true' : 'false'}`}
+        {`: ${hideProgressBar ? 'true' : 'false'}`},
       </div>
       <div>
         <span className="code__props">closeOnClick</span>
-        {`: ${closeOnClick ? 'true' : 'false'}`}
+        {`: ${closeOnClick ? 'true' : 'false'}`},
       </div>
       <div>
         <span className="code__props">pauseOnHover</span>
-        {`: ${pauseOnHover ? 'true' : 'false'}`}
+        {`: ${pauseOnHover ? 'true' : 'false'}`},
       </div>
       <div>
         <span className="code__props">draggable</span>
-        {`: ${draggable ? 'true' : 'false'}`}
+        {`: ${draggable ? 'true' : 'false'}`},
       </div>
       {!Number.isNaN(parseFloat(progress)) && (
         <div>
           <span className="code__props">progress</span>
-          {`: ${progress}`}
+          {`: ${progress}`},
         </div>
       )}
       <div>{`});`}</div>

--- a/playground/index.css
+++ b/playground/index.css
@@ -139,8 +139,10 @@ label{
 }
 
 .code {
+    font-family: "Source Code Pro", Menlo, Monaco, Courier, monospace;
     font-size: 12px;
-    font-style: italic;
+    line-height: 1.4;
+    font-style: normal;
     border-left: 3px solid #a9547e;
     padding-left: 20px;
     background: #222;


### PR DESCRIPTION
This PR adds:

- A monospace font stack and slightly modified styles for the code blocks 017d1f2
- The missing commas to Toast Emitter code sample d852a3c

Currently:

<img width="487" alt="Screenshot 2019-10-09 12 35 53" src="https://user-images.githubusercontent.com/1581276/66514118-60ff1c80-ea91-11e9-8fc8-ebd5868dbcb4.png">

Revised:

<img width="491" alt="Screenshot 2019-10-09 12 36 47" src="https://user-images.githubusercontent.com/1581276/66514196-7a07cd80-ea91-11e9-98b2-152685b2acc3.png">

Thanks for the work on this library!