### PR TITLE
Cancellation WILL_UNMOUNT event when the container is mounted again

### DIFF
--- a/src/__tests__/components/ToastContainer.js
+++ b/src/__tests__/components/ToastContainer.js
@@ -37,6 +37,19 @@ describe('ToastContainer', () => {
     expect(eventManager.list.has(ACTION.CLEAR)).toBeFalsy();
   });
 
+  it('Should bind event when re-mounted', () => {
+    const component = mount(<ToastContainer />);
+
+    expect(eventManager.list.has(ACTION.SHOW)).toBeTruthy();
+    expect(eventManager.list.has(ACTION.CLEAR)).toBeTruthy();
+
+    component.unmount().mount();
+    jest.runAllTimers();    
+
+    expect(eventManager.list.has(ACTION.SHOW)).toBeTruthy();
+    expect(eventManager.list.has(ACTION.CLEAR)).toBeTruthy();
+  });
+
   it(`Should always pass down to Toast the props: 
     -autoClose
     -closeButton

--- a/src/components/ToastContainer.js
+++ b/src/components/ToastContainer.js
@@ -177,6 +177,7 @@ class ToastContainer extends Component {
 
   componentDidMount() {
     eventManager
+      .cancelEmit(ACTION.WILL_UNMOUNT)
       .on(ACTION.SHOW, (content, options) => this.buildToast(content, options))
       .on(ACTION.CLEAR, id =>
         id == null ? this.clear() : this.removeToast(id)

--- a/src/utils/eventManager.js
+++ b/src/utils/eventManager.js
@@ -1,5 +1,6 @@
 export const eventManager = {
   list: new Map(),
+  emitQueue: new Map(),
 
   on(event, callback) {
     this.list.has(event) || this.list.set(event, []);
@@ -9,6 +10,16 @@ export const eventManager = {
 
   off(event) {
     this.list.delete(event);
+    return this;
+  },
+
+  cancelEmit(event) {
+    const timers = this.emitQueue.get(event);
+    if (timers) {
+      timers.forEach(timer => clearTimeout(timer));
+      this.emitQueue.delete(event);
+    }
+
     return this;
   },
 
@@ -22,10 +33,13 @@ export const eventManager = {
    */
   emit(event, ...args) {
     this.list.has(event) &&
-      this.list.get(event).forEach(callback =>
-        setTimeout(() => {
+      this.list.get(event).forEach(callback => {
+        const timer = setTimeout(() => {
           callback(...args);
-        }, 0)
-      );
+        }, 0);
+
+        this.emitQueue.has(event) || this.emitQueue.set(event, []);
+        this.emitQueue.get(event).push(timer);
+      });
   }
 };


### PR DESCRIPTION
In the current version, EventManager handles the `Will_Mount` event after the container has been remounted. In this case, `SHOW` event will not be attached.

I've added the ability to cancel timers that trigger events.