### PR TITLE
fix(closeButton): prevent cross button to be an emoji

### DIFF
--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -13,7 +13,7 @@ function CloseButton({ closeToast, type, ariaLabel }) {
       }}
       aria-label={ariaLabel}
     >
-      ✖
+      ✖︎
     </button>
   );
 }


### PR DESCRIPTION
fixes #259 

This is happening, since the "heavy cross" is an emoji on iOS, and thus won't accept any styling. This changed it to the text version, with the u+FEOE character after it (VS15), as mentioned in https://www.unicode.org/Public/UCD/latest/ucd/StandardizedVariants.txt

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 