### PR TITLE
Make toast body flex properties more explicit

### DIFF
--- a/scss/_toast.scss
+++ b/scss/_toast.scss
@@ -34,7 +34,7 @@
     }
     &-body {
         margin: auto 0;
-        flex: 1;
+        flex: 1 1 auto;
     }
 }
 


### PR DESCRIPTION
Using `flex: 1` evaluates to `flex-basis: 0` which doesn't always work in IE11. Explicitly define `flex-basis: auto`.

Reference: https://makandracards.com/makandra/54644-do-not-use-flex-1-or-flex-basis-0-inside-flex-direction-column-when-you-need-to-support-ie11

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 