### PR TITLE
Reset translateX for mobile (top/bottom-center)

### DIFF
--- a/scss/_toastContainer.scss
+++ b/scss/_toastContainer.scss
@@ -44,11 +44,13 @@
         &--top-center,
         &--top-right {
             top: 0;
+            transform: translateX(0);
         }
         &--bottom-left,
         &--bottom-center,
         &--bottom-right {
             bottom: 0;
+            transform: translateX(0);
         }
         &--rtl{
           right: 0;


### PR DESCRIPTION
Fix regression for mobile in case top-center or bottom-center introduced in #430. The translate(50%) was hiding half of the notification.

NIT: Probably yarn install in example should be done on post-install. 