### PR TITLE
Type Improvements, other misc details

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,10 @@
 1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
 2. Run `yarn` in the repository root.
 3. If you've fixed a bug or added code that should be tested, add tests!
-4. Ensure the test suite passes (`yarn test`).
+4. Ensure the test suites pass (`yarn test`).
 5. Run `yarn start` to test your changes in the playground.
-6. Update the readme is needed
-7. Update the typescript definition is needed
-8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
-9. Make sure your code lints (`yarn lint:fix`).
+6. Update the readme if needed
+7. Update the typescript definitions if needed
+8. Make sure your code lints (`yarn lint`).
 
 **Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ yarn start
 # Run tests 💩
 yarn test
 
-# Prettify all the things
-yarn prettier-all
+# Lint all the things
+yarn lint
 ```
 
 ### Project structure

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -8,7 +8,7 @@ import { CloseButton } from './CloseButton';
 import { Bounce } from './Transitions';
 import { POSITION, DEFAULT, parseClassName, objectValues } from '../utils';
 import { useToastContainer } from '../hooks';
-import { ToastContainerProps, ToastPosition } from '../types';
+import { ToastContainerProps } from '../types';
 import { ToastPositioner } from './ToastPositioner';
 
 export const ToastContainer: React.FC<ToastContainerProps> = props => {
@@ -102,7 +102,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 ToastContainer.defaultProps = {
-  position: POSITION.TOP_RIGHT as ToastPosition,
+  position: POSITION.TOP_RIGHT,
   transition: Bounce,
   rtl: false,
   autoClose: 5000,

--- a/src/hooks/useToastContainer.ts
+++ b/src/hooks/useToastContainer.ts
@@ -14,7 +14,8 @@ import {
   isNum,
   isStr,
   hasToastId,
-  getAutoCloseDelay
+  getAutoCloseDelay,
+  ToastPosition
 } from '../utils';
 
 import {
@@ -23,7 +24,6 @@ import {
   ToastProps,
   ToastContent,
   Toast,
-  ToastPosition,
   ClearWaitingQueueParams,
   NotValidatedToastProps,
   ToastTransition
@@ -175,7 +175,7 @@ export function useToastContainer(props: ToastContainerProps) {
       closeToast: closeToast,
       closeButton: options.closeButton,
       rtl: props.rtl,
-      position: options.position || (props.position as ToastPosition),
+      position: options.position || props.position,
       transition: options.transition || (props.transition as ToastTransition),
       className: parseClassName(options.className || props.toastClassName),
       bodyClassName: parseClassName(
@@ -287,9 +287,10 @@ export function useToastContainer(props: ToastContainerProps) {
     for (let i = 0; i < toastList.length; i++) {
       const toast = collection[toastList[i]];
       const { position } = toast.props;
-      toastToRender[position] || (toastToRender[position] = []);
-
-      toastToRender[position]!.push(toast);
+      if (position) {
+        toastToRender[position] || (toastToRender[position] = []);
+        toastToRender[position]!.push(toast);
+      }
     }
 
     return (Object.keys(toastToRender) as Array<ToastPosition>).map(p =>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,10 @@
 export { useToastContainer, useToast } from './hooks';
-export { cssTransition, collapseToast } from './utils';
+export {
+  cssTransition,
+  collapseToast,
+  ToastPosition,
+  TypeOptions
+} from './utils';
 export { ToastContainer, Bounce, Flip, Slide, Zoom } from './components';
 export { toast } from './core';
 export * from './types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,21 +1,14 @@
 import * as React from 'react';
+import { ToastPosition, TypeOptions } from '../utils';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
-export type ToastPosition =
-  | 'top-right'
-  | 'top-center'
-  | 'top-left'
-  | 'bottom-right'
-  | 'bottom-center'
-  | 'bottom-left';
-
 export interface ToastContentProps {
   closeToast?: () => void;
 }
-export type TypeOptions = 'info' | 'success' | 'warning' | 'error' | 'default';
+
 export type ToastContent =
   | React.ReactNode
   | ((props: ToastContentProps) => React.ReactNode);
@@ -201,7 +194,7 @@ export interface ToastProps extends ToastOptions {
   key: Id;
   transition: ToastTransition;
   closeToast: () => void;
-  position: ToastPosition;
+  position?: ToastPosition;
   children?: ToastContent;
   draggablePercent: number;
   progressClassName?: ClassName;
@@ -263,7 +256,7 @@ export interface ToastTransitionProps {
   in: boolean;
   appear: boolean;
   done: () => void;
-  position: ToastPosition | string;
+  position?: ToastPosition | string;
   preventExitTransition: boolean;
   nodeRef: React.RefObject<HTMLElement>;
   children?: React.ReactNode;

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,22 +1,29 @@
-export type TypeOptions = 'info' | 'success' | 'warning' | 'error' | 'default';
-export type Positons =
-  | 'top-left'
+export type ToastPosition =
   | 'top-right'
   | 'top-center'
-  | 'bottom-left'
+  | 'top-left'
   | 'bottom-right'
-  | 'bottom-center';
+  | 'bottom-center'
+  | 'bottom-left';
 
-export const POSITION = {
+export type TypeOptions =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'dark'
+  | 'default';
+
+export const POSITION: { [key: string]: ToastPosition } = {
   TOP_LEFT: 'top-left',
   TOP_RIGHT: 'top-right',
   TOP_CENTER: 'top-center',
   BOTTOM_LEFT: 'bottom-left',
   BOTTOM_RIGHT: 'bottom-right',
   BOTTOM_CENTER: 'bottom-center'
-} as const;
+};
 
-export const TYPE = {
+export const TYPE: { [key: string]: TypeOptions } = {
   INFO: 'info',
   SUCCESS: 'success',
   WARNING: 'warning',


### PR DESCRIPTION
This scope-crept a little, but now the `as` call isn't necessary.
Fixed up a few other spots while I was in here

Position is now optional so this could be a "breaking" change.

There's no more prettier so I'm unsure if all those references should be nuked. And no `lint:fix`