### PR TITLE
Add toast props to content callback

### DIFF
--- a/src/hooks/useToastContainer.ts
+++ b/src/hooks/useToastContainer.ts
@@ -232,10 +232,11 @@ export function useToastContainer(props: ToastContainerProps) {
 
     if (isValidElement(content) && !isStr(content.type)) {
       toastContent = cloneElement(content, {
-        closeToast
+        closeToast,
+        toastProps
       });
     } else if (isFn(content)) {
-      toastContent = content({ closeToast });
+      toastContent = content({ closeToast, toastProps });
     }
 
     // not handling limit + delay by design. Waiting for user feedback first

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type ToastPosition =
 
 export interface ToastContentProps {
   closeToast?: () => void;
+  toastProps: ToastProps;
 }
 export type ToastContent =
   | React.ReactNode


### PR DESCRIPTION
When toast content is render by component or function, the toast props are passed to component/function.

**Example:**
```
const Msg = ({toastProps, children}) => {
  return <div className={`alert alert-${toastProps.variant}`}>{children}</div>;
}; 

toast.success(<Msg>Toast content</Msg>);
```