### PR TITLE
feat: instantiation of `toast` is wrapped in a factory

### DIFF
--- a/src/core/eventManager.ts
+++ b/src/core/eventManager.ts
@@ -62,15 +62,15 @@ export interface EventManager {
   emit(event: Event.Change, toast: number, containerId?: number | string): void;
 }
 
-export const createEventManager = () => ({
-  list: new Map(),
-  emitQueue: new Map(),
+class EvtManager implements EventManager {
+  list = new Map();
+  emitQueue = new Map();
 
   on(event: Event, callback: Callback) {
     this.list.has(event) || this.list.set(event, []);
     this.list.get(event)!.push(callback);
     return this;
-  },
+  }
 
   off(event: Event, callback: Callback) {
     if (callback) {
@@ -82,7 +82,7 @@ export const createEventManager = () => ({
     }
     this.list.delete(event);
     return this;
-  },
+  }
 
   cancelEmit(event: Event) {
     const timers = this.emitQueue.get(event);
@@ -92,7 +92,7 @@ export const createEventManager = () => ({
     }
 
     return this;
-  },
+  }
 
   /**
    * Enqueue the event at the end of the call stack
@@ -114,6 +114,8 @@ export const createEventManager = () => ({
         this.emitQueue.get(event)!.push(timer);
       });
   }
-});
+}
 
-export const eventManager: EventManager = createEventManager();
+export const createEventManager = (): EventManager => new EvtManager();
+
+export const eventManager = createEventManager();

--- a/src/core/eventManager.ts
+++ b/src/core/eventManager.ts
@@ -62,7 +62,7 @@ export interface EventManager {
   emit(event: Event.Change, toast: number, containerId?: number | string): void;
 }
 
-export const eventManager: EventManager = {
+export const createEventManager = () => ({
   list: new Map(),
   emitQueue: new Map(),
 
@@ -72,9 +72,11 @@ export const eventManager: EventManager = {
     return this;
   },
 
-  off(event, callback) {
+  off(event: Event, callback: Callback) {
     if (callback) {
-      const cb = this.list.get(event)!.filter(cb => cb !== callback);
+      const cb = this.list
+        .get(event)!
+        .filter((cb: Callback) => cb !== callback);
       this.list.set(event, cb);
       return this;
     }
@@ -82,7 +84,7 @@ export const eventManager: EventManager = {
     return this;
   },
 
-  cancelEmit(event) {
+  cancelEmit(event: Event) {
     const timers = this.emitQueue.get(event);
     if (timers) {
       timers.forEach((timer: TimeoutId) => clearTimeout(timer));
@@ -112,4 +114,6 @@ export const eventManager: EventManager = {
         this.emitQueue.get(event)!.push(timer);
       });
   }
-};
+});
+
+export const eventManager: EventManager = createEventManager();

--- a/src/core/toast.tsx
+++ b/src/core/toast.tsx
@@ -28,36 +28,36 @@ interface EnqueuedToast {
   options: NotValidatedToastProps;
 }
 
+/**
+ * Generate a random toastId
+ */
+function generateToastId() {
+  return (Math.random().toString(36) + Date.now().toString(36)).substr(2, 10);
+}
+
+/**
+ * Generate a toastId or use the one provided
+ */
+function getToastId(options?: ToastOptions) {
+  if (options && (isStr(options.toastId) || isNum(options.toastId))) {
+    return options.toastId;
+  }
+
+  return generateToastId();
+}
+
+/**
+ * Merge provided options with the defaults settings and generate the toastId
+ */
+function mergeOptions(type: string, options?: ToastOptions) {
+  return {
+    ...options,
+    type: (options && options.type) || type,
+    toastId: getToastId(options)
+  } as NotValidatedToastProps;
+}
+
 class ToastManager extends Function {
-  /**
-   * Generate a random toastId
-   */
-  private static generateToastId() {
-    return (Math.random().toString(36) + Date.now().toString(36)).substr(2, 10);
-  }
-
-  /**
-   * Generate a toastId or use the one provided
-   */
-  private static getToastId(options?: ToastOptions) {
-    if (options && (isStr(options.toastId) || isNum(options.toastId))) {
-      return options.toastId;
-    }
-
-    return ToastManager.generateToastId();
-  }
-
-  /**
-   * Merge provided options with the defaults settings and generate the toastId
-   */
-  private static mergeOptions(type: string, options?: ToastOptions) {
-    return {
-      ...options,
-      type: (options && options.type) || type,
-      toastId: ToastManager.getToastId(options)
-    } as NotValidatedToastProps;
-  }
-
   private containers = new Map<ContainerInstance | Id, ContainerInstance>();
   private latestInstance!: ContainerInstance | Id;
   private containerDomNode!: HTMLElement;
@@ -155,45 +155,27 @@ class ToastManager extends Function {
   };
 
   public default = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.DEFAULT, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.DEFAULT, options));
   };
 
   public success = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.SUCCESS, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.SUCCESS, options));
   };
 
   public info = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.INFO, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.INFO, options));
   };
 
   public error = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.ERROR, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.ERROR, options));
   };
 
   public warning = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.WARNING, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.WARNING, options));
   };
 
   public dark = (content: ToastContent, options?: ToastOptions) => {
-    return this.dispatchToast(
-      content,
-      ToastManager.mergeOptions(TYPE.DARK, options)
-    );
+    return this.dispatchToast(content, mergeOptions(TYPE.DARK, options));
   };
 
   /**
@@ -249,7 +231,7 @@ class ToastManager extends Function {
           ...oldOptions,
           ...options,
           toastId: options.toastId || toastId,
-          updateId: ToastManager.generateToastId()
+          updateId: generateToastId()
         } as ToastProps & UpdateOptions;
 
         if (nextOptions.toastId !== toastId) nextOptions.staleId = toastId;

--- a/src/core/toast.tsx
+++ b/src/core/toast.tsx
@@ -1,17 +1,24 @@
 import * as React from 'react';
+import { PropsWithChildren, useContext } from 'react';
 import { render } from 'react-dom';
 
-import { POSITION, TYPE, canUseDom, isStr, isNum, isFn } from '../utils';
-import { eventManager, OnChangeCallback, Event } from './eventManager';
+import { canUseDom, isFn, isNum, isStr, POSITION, TYPE } from '../utils';
 import {
+  createEventManager,
+  Event,
+  eventManager,
+  EventManager,
+  OnChangeCallback
+} from './eventManager';
+import {
+  ClearWaitingQueueParams,
+  Id,
+  NotValidatedToastProps,
+  ToastContainerProps,
   ToastContent,
   ToastOptions,
   ToastProps,
-  Id,
-  ToastContainerProps,
-  UpdateOptions,
-  ClearWaitingQueueParams,
-  NotValidatedToastProps
+  UpdateOptions
 } from '../types';
 import { ContainerInstance } from 'hooks';
 import { ToastContainer } from '../components';
@@ -21,229 +28,256 @@ interface EnqueuedToast {
   options: NotValidatedToastProps;
 }
 
-let containers = new Map<ContainerInstance | Id, ContainerInstance>();
-let latestInstance: ContainerInstance | Id;
-let containerDomNode: HTMLElement;
-let containerConfig: ToastContainerProps;
-let queue: EnqueuedToast[] = [];
-let lazy = false;
+const createToastManager = (
+  evtManager: EventManager = createEventManager()
+) => {
+  let containers = new Map<ContainerInstance | Id, ContainerInstance>();
+  let latestInstance: ContainerInstance | Id;
+  let containerDomNode: HTMLElement;
+  let containerConfig: ToastContainerProps;
+  let queue: EnqueuedToast[] = [];
+  let lazy = false;
 
-/**
- * Check whether any container is currently mounted in the DOM
- */
-function isAnyContainerMounted() {
-  return containers.size > 0;
-}
+  /**
+   * Check whether any container is currently mounted in the DOM
+   */
+  function isAnyContainerMounted() {
+    return containers.size > 0;
+  }
 
-/**
- * Get the container by id. Returns the last container declared when no id is given.
- */
-function getContainer(containerId?: Id) {
-  if (!isAnyContainerMounted()) return null;
-  return containers.get(!containerId ? latestInstance : containerId);
-}
+  /**
+   * Get the container by id. Returns the last container declared when no id is given.
+   */
+  function getContainer(containerId?: Id) {
+    if (!isAnyContainerMounted()) return null;
+    return containers.get(!containerId ? latestInstance : containerId);
+  }
 
-/**
- * Get the toast by id, given it's in the DOM, otherwise returns null
- */
-function getToast(toastId: Id, { containerId }: ToastOptions) {
-  const container = getContainer(containerId);
-  if (!container) return null;
+  /**
+   * Get the toast by id, given it's in the DOM, otherwise returns null
+   */
+  function getToast(toastId: Id, { containerId }: ToastOptions) {
+    const container = getContainer(containerId);
+    if (!container) return null;
 
-  return container.getToast(toastId);
-}
+    return container.getToast(toastId);
+  }
 
-/**
- * Generate a random toastId
- */
-function generateToastId() {
-  return (Math.random().toString(36) + Date.now().toString(36)).substr(2, 10);
-}
+  /**
+   * Generate a random toastId
+   */
+  function generateToastId() {
+    return (Math.random().toString(36) + Date.now().toString(36)).substr(2, 10);
+  }
 
-/**
- * Generate a toastId or use the one provided
- */
-function getToastId(options?: ToastOptions) {
-  if (options && (isStr(options.toastId) || isNum(options.toastId))) {
+  /**
+   * Generate a toastId or use the one provided
+   */
+  function getToastId(options?: ToastOptions) {
+    if (options && (isStr(options.toastId) || isNum(options.toastId))) {
+      return options.toastId;
+    }
+
+    return generateToastId();
+  }
+
+  /**
+   * If the container is not mounted, the toast is enqueued and
+   * the container lazy mounted
+   */
+  function dispatchToast(
+    content: ToastContent,
+    options: NotValidatedToastProps
+  ): Id {
+    if (isAnyContainerMounted()) {
+      evtManager.emit(Event.Show, content, options);
+    } else {
+      queue.push({ content, options });
+      if (lazy && canUseDom) {
+        lazy = false;
+        containerDomNode = document.createElement('div');
+        document.body.appendChild(containerDomNode);
+        render(<ToastContainer {...containerConfig} />, containerDomNode);
+      }
+    }
+
     return options.toastId;
   }
 
-  return generateToastId();
-}
-
-/**
- * If the container is not mounted, the toast is enqueued and
- * the container lazy mounted
- */
-function dispatchToast(
-  content: ToastContent,
-  options: NotValidatedToastProps
-): Id {
-  if (isAnyContainerMounted()) {
-    eventManager.emit(Event.Show, content, options);
-  } else {
-    queue.push({ content, options });
-    if (lazy && canUseDom) {
-      lazy = false;
-      containerDomNode = document.createElement('div');
-      document.body.appendChild(containerDomNode);
-      render(<ToastContainer {...containerConfig} />, containerDomNode);
-    }
+  /**
+   * Merge provided options with the defaults settings and generate the toastId
+   */
+  function mergeOptions(type: string, options?: ToastOptions) {
+    return {
+      ...options,
+      type: (options && options.type) || type,
+      toastId: getToastId(options)
+    } as NotValidatedToastProps;
   }
 
-  return options.toastId;
-}
+  const toast = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.DEFAULT, options));
 
-/**
- * Merge provided options with the defaults settings and generate the toastId
- */
-function mergeOptions(type: string, options?: ToastOptions) {
-  return {
-    ...options,
-    type: (options && options.type) || type,
-    toastId: getToastId(options)
-  } as NotValidatedToastProps;
-}
+  toast.success = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.SUCCESS, options));
 
-const toast = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.DEFAULT, options));
+  toast.info = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.INFO, options));
 
-toast.success = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.SUCCESS, options));
+  toast.error = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.ERROR, options));
 
-toast.info = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.INFO, options));
+  toast.warning = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.WARNING, options));
 
-toast.error = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.ERROR, options));
+  toast.dark = (content: ToastContent, options?: ToastOptions) =>
+    dispatchToast(content, mergeOptions(TYPE.DARK, options));
 
-toast.warning = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.WARNING, options));
+  /**
+   * Maybe I should remove warning in favor of warn, I don't know
+   */
+  toast.warn = toast.warning;
 
-toast.dark = (content: ToastContent, options?: ToastOptions) =>
-  dispatchToast(content, mergeOptions(TYPE.DARK, options));
+  /**
+   * Remove toast programmaticaly
+   */
+  toast.dismiss = (id?: Id) =>
+    isAnyContainerMounted() && evtManager.emit(Event.Clear, id);
 
-/**
- * Maybe I should remove warning in favor of warn, I don't know
- */
-toast.warn = toast.warning;
+  /**
+   * Clear waiting queue when limit is used
+   */
+  toast.clearWaitingQueue = (params: ClearWaitingQueueParams = {}) =>
+    isAnyContainerMounted() && evtManager.emit(Event.ClearWaitingQueue, params);
 
-/**
- * Remove toast programmaticaly
- */
-toast.dismiss = (id?: Id) =>
-  isAnyContainerMounted() && eventManager.emit(Event.Clear, id);
+  /**
+   * return true if one container is displaying the toast
+   */
+  toast.isActive = (id: Id) => {
+    let isToastActive = false;
 
-/**
- * Clear waiting queue when limit is used
- */
-toast.clearWaitingQueue = (params: ClearWaitingQueueParams = {}) =>
-  isAnyContainerMounted() && eventManager.emit(Event.ClearWaitingQueue, params);
-
-/**
- * return true if one container is displaying the toast
- */
-toast.isActive = (id: Id) => {
-  let isToastActive = false;
-
-  containers.forEach(container => {
-    if (container.isToastActive && container.isToastActive(id)) {
-      isToastActive = true;
-    }
-  });
-
-  return isToastActive;
-};
-
-toast.update = (toastId: Id, options: UpdateOptions = {}) => {
-  // if you call toast and toast.update directly nothing will be displayed
-  // this is why I defered the update
-  setTimeout(() => {
-    const toast = getToast(toastId, options as ToastOptions);
-    if (toast) {
-      const { props: oldOptions, content: oldContent } = toast;
-
-      const nextOptions = {
-        ...oldOptions,
-        ...options,
-        toastId: options.toastId || toastId,
-        updateId: generateToastId()
-      } as ToastProps & UpdateOptions;
-
-      if (nextOptions.toastId !== toastId) nextOptions.staleId = toastId;
-
-      const content =
-        typeof nextOptions.render !== 'undefined'
-          ? nextOptions.render
-          : oldContent;
-      delete nextOptions.render;
-
-      dispatchToast(content, nextOptions);
-    }
-  }, 0);
-};
-
-/**
- * Used for controlled progress bar.
- */
-toast.done = (id: Id) => {
-  toast.update(id, {
-    progress: 1
-  });
-};
-
-/**
- * Track changes. The callback get the number of toast displayed
- *
- */
-toast.onChange = (callback: OnChangeCallback) => {
-  if (isFn(callback)) {
-    eventManager.on(Event.Change, callback);
-  }
-  return () => {
-    isFn(callback) && eventManager.off(Event.Change, callback);
-  };
-};
-
-/**
- * Configure the ToastContainer when lazy mounted
- */
-toast.configure = (config: ToastContainerProps = {}) => {
-  lazy = true;
-  containerConfig = config;
-};
-
-toast.POSITION = POSITION;
-toast.TYPE = TYPE;
-
-/**
- * Wait until the ToastContainer is mounted to dispatch the toast
- * and attach isActive method
- */
-eventManager
-  .on(Event.DidMount, (containerInstance: ContainerInstance) => {
-    latestInstance = containerInstance.containerId || containerInstance;
-    containers.set(latestInstance, containerInstance);
-
-    queue.forEach(item => {
-      eventManager.emit(Event.Show, item.content, item.options);
+    containers.forEach(container => {
+      if (container.isToastActive && container.isToastActive(id)) {
+        isToastActive = true;
+      }
     });
 
-    queue = [];
-  })
-  .on(Event.WillUnmount, (containerInstance: ContainerInstance) => {
-    containers.delete(containerInstance.containerId || containerInstance);
+    return isToastActive;
+  };
 
-    if (containers.size === 0) {
-      eventManager
-        .off(Event.Show)
-        .off(Event.Clear)
-        .off(Event.ClearWaitingQueue);
+  toast.update = (toastId: Id, options: UpdateOptions = {}) => {
+    // if you call toast and toast.update directly nothing will be displayed
+    // this is why I defered the update
+    setTimeout(() => {
+      const toast = getToast(toastId, options as ToastOptions);
+      if (toast) {
+        const { props: oldOptions, content: oldContent } = toast;
+
+        const nextOptions = {
+          ...oldOptions,
+          ...options,
+          toastId: options.toastId || toastId,
+          updateId: generateToastId()
+        } as ToastProps & UpdateOptions;
+
+        if (nextOptions.toastId !== toastId) nextOptions.staleId = toastId;
+
+        const content =
+          typeof nextOptions.render !== 'undefined'
+            ? nextOptions.render
+            : oldContent;
+        delete nextOptions.render;
+
+        dispatchToast(content, nextOptions);
+      }
+    }, 0);
+  };
+
+  /**
+   * Used for controlled progress bar.
+   */
+  toast.done = (id: Id) => {
+    toast.update(id, {
+      progress: 1
+    });
+  };
+
+  /**
+   * Track changes. The callback get the number of toast displayed
+   *
+   */
+  toast.onChange = (callback: OnChangeCallback) => {
+    if (isFn(callback)) {
+      evtManager.on(Event.Change, callback);
     }
+    return () => {
+      isFn(callback) && evtManager.off(Event.Change, callback);
+    };
+  };
 
-    if (canUseDom && containerDomNode) {
-      document.body.removeChild(containerDomNode);
-    }
-  });
+  /**
+   * Configure the ToastContainer when lazy mounted
+   */
+  toast.configure = (config: ToastContainerProps = {}) => {
+    lazy = true;
+    containerConfig = config;
+  };
 
-export { toast };
+  toast.POSITION = POSITION;
+  toast.TYPE = TYPE;
+
+  /**
+   * Wait until the ToastContainer is mounted to dispatch the toast
+   * and attach isActive method
+   */
+  evtManager
+    .on(Event.DidMount, (containerInstance: ContainerInstance) => {
+      latestInstance = containerInstance.containerId || containerInstance;
+      containers.set(latestInstance, containerInstance);
+
+      queue.forEach(item => {
+        evtManager.emit(Event.Show, item.content, item.options);
+      });
+
+      queue = [];
+    })
+    .on(Event.WillUnmount, (containerInstance: ContainerInstance) => {
+      containers.delete(containerInstance.containerId || containerInstance);
+
+      if (containers.size === 0) {
+        evtManager
+          .off(Event.Show)
+          .off(Event.Clear)
+          .off(Event.ClearWaitingQueue);
+      }
+
+      if (canUseDom && containerDomNode) {
+        document.body.removeChild(containerDomNode);
+      }
+    });
+
+  toast.Provider = (
+    props: PropsWithChildren<Omit<ToastContainerProps, 'eventManager'>>
+  ) => {
+    const { children, ...rest } = props;
+
+    return (
+      <ToastManagerContext.Provider value={toast}>
+        {children}
+        <ToastContainer {...rest} eventManager={evtManager} />
+      </ToastManagerContext.Provider>
+    );
+  };
+
+  return toast;
+};
+
+const toast = createToastManager(eventManager);
+
+export type ToastManager = ReturnType<typeof createToastManager>;
+
+const ToastManagerContext = React.createContext<ToastManager>(toast);
+
+const useToastManager = () => useContext(ToastManagerContext);
+
+export { toast, createToastManager, useToastManager };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { EventManager } from 'core';
+import { CloseButtonProps } from 'components';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | null;
@@ -80,7 +82,7 @@ interface CommonOptions {
    */
   closeButton?:
     | React.ReactElement
-    | ((props: any) => React.ReactElement)
+    | ((props: CloseButtonProps) => React.ReactElement)
     | boolean;
 
   /**
@@ -264,6 +266,11 @@ export interface ToastContainerProps extends CommonOptions {
    * Limit the number of toast displayed at the same time
    */
   limit?: number;
+
+  /**
+   * Event manager to handle the toasts appearance. Omit to use default global
+   */
+  eventManager?: EventManager;
 }
 
 export interface ToastTransitionProps {

--- a/test/core/createToastManager.test.tsx
+++ b/test/core/createToastManager.test.tsx
@@ -28,12 +28,7 @@ const FirstInnerComponent = () => {
       </button>
       <button
         data-testid={TestId.FirstTriggerBtn}
-        onClick={() => {
-          // @ts-ignore
-          console.log('>__::: containers', toast.containers.size);
-
-          toast(<div data-testid={TestId.Notification}>Notify A</div>);
-        }}
+        onClick={() => toast(<div data-testid={TestId.Notification}>Notify A</div>)}
       >
         Notify for A
       </button>

--- a/test/core/createToastManager.test.tsx
+++ b/test/core/createToastManager.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render, fireEvent, RenderResult } from '@testing-library/react';
+import '../__mocks__/react-transition-group';
+
+import { createToastManager, ToastManager, useToastManager } from '../../src/core';
+
+jest.useFakeTimers();
+
+enum TestId {
+  Notification = 'notif',
+  FirstTriggerBtn = 'button-a',
+  FirstClearAllBtn = 'clear-all-a',
+  SecondTriggerBtn = 'button-b',
+  SecondCloseBtn = 'close-b-notif',
+}
+
+const FirstInnerComponent = () => {
+  const toast = useToastManager();
+
+  return (
+    <div>
+      <button
+        data-testid={TestId.FirstClearAllBtn}
+        onClick={() => toast.dismiss()}
+      >
+        Clear A
+      </button>
+      <button
+        data-testid={TestId.FirstTriggerBtn}
+        onClick={() =>
+          toast(<div data-testid={TestId.Notification}>Notify A</div>)
+        }
+      >
+        Notify for A
+      </button>
+    </div>
+  );
+};
+
+const SecondInnerComponent = () => {
+  const toast = useToastManager();
+
+  return (
+    <div>
+      <button
+        data-testid={TestId.SecondTriggerBtn}
+        onClick={() =>
+          toast(<div data-testid={TestId.Notification}>Notify B</div>)
+        }
+      >
+        Notify for A
+      </button>
+    </div>
+  );
+};
+
+describe('createToastManager', () => {
+  let rr: RenderResult;
+  let firstToastManager: ToastManager;
+  let secondToastManager: ToastManager;
+
+  beforeEach(() => {
+    firstToastManager = createToastManager();
+    secondToastManager = createToastManager();
+
+    rr = render(
+      <div>
+        <firstToastManager.Provider>
+          <div>
+            First sub three
+            <FirstInnerComponent />
+          </div>
+        </firstToastManager.Provider>
+
+        <secondToastManager.Provider
+          closeButton={({ closeToast }) => (
+            <button data-testid={TestId.SecondCloseBtn} onClick={closeToast}>
+              Close A
+            </button>
+          )}
+        >
+          <div>
+            Second sub three
+            <SecondInnerComponent />
+          </div>
+        </secondToastManager.Provider>
+      </div>
+    );
+  });
+
+  it('should show toaster using manager api', () => {
+    act(() => {
+      fireEvent.click(rr.getByTestId(TestId.FirstTriggerBtn));
+      jest.runTimersToTime(0);
+    });
+
+    expect(rr.getByTestId(TestId.Notification).textContent).toEqual('Notify A');
+  });
+
+  it('should show toasters from both managers', () => {
+    act(() => {
+      fireEvent.click(rr.getByTestId(TestId.FirstTriggerBtn));
+      fireEvent.click(rr.getByTestId(TestId.SecondTriggerBtn));
+      jest.runTimersToTime(0);
+    });
+
+    const texts = rr
+      .getAllByTestId(TestId.Notification)
+      .map(el => el.textContent);
+
+    expect(texts).toHaveLength(2);
+    expect(texts).toContain('Notify A');
+    expect(texts).toContain('Notify B');
+  });
+
+  it('should dismiss first toast via clear all and keep second', () => {
+    act(() => {
+      fireEvent.click(rr.getByTestId(TestId.FirstTriggerBtn));
+      fireEvent.click(rr.getByTestId(TestId.SecondTriggerBtn));
+      jest.runTimersToTime(0);
+      fireEvent.click(rr.getByTestId(TestId.FirstClearAllBtn));
+      jest.runTimersToTime(0);
+    });
+
+    expect(rr.getByTestId(TestId.Notification).textContent).toEqual('Notify B');
+  });
+
+  it('should be able to close second toast via button defined in provider prop', () => {
+    act(() => {
+      fireEvent.click(rr.getByTestId(TestId.FirstTriggerBtn));
+      fireEvent.click(rr.getByTestId(TestId.SecondTriggerBtn));
+      jest.runTimersToTime(0);
+      fireEvent.click(rr.getByTestId(TestId.SecondCloseBtn));
+      jest.runTimersToTime(0);
+    });
+
+    expect(rr.getByTestId(TestId.Notification).textContent).toEqual('Notify A');
+  });
+});

--- a/test/core/createToastManager.test.tsx
+++ b/test/core/createToastManager.test.tsx
@@ -3,7 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { render, fireEvent, RenderResult } from '@testing-library/react';
 import '../__mocks__/react-transition-group';
 
-import { createToastManager, ToastManager, useToastManager } from '../../src/core';
+import { createToastManager, useToastManager } from '../../src/core';
 
 jest.useFakeTimers();
 
@@ -12,7 +12,7 @@ enum TestId {
   FirstTriggerBtn = 'button-a',
   FirstClearAllBtn = 'clear-all-a',
   SecondTriggerBtn = 'button-b',
-  SecondCloseBtn = 'close-b-notif',
+  SecondCloseBtn = 'close-b-notif'
 }
 
 const FirstInnerComponent = () => {
@@ -28,9 +28,12 @@ const FirstInnerComponent = () => {
       </button>
       <button
         data-testid={TestId.FirstTriggerBtn}
-        onClick={() =>
-          toast(<div data-testid={TestId.Notification}>Notify A</div>)
-        }
+        onClick={() => {
+          // @ts-ignore
+          console.log('>__::: containers', toast.containers.size);
+
+          toast(<div data-testid={TestId.Notification}>Notify A</div>);
+        }}
       >
         Notify for A
       </button>
@@ -55,10 +58,10 @@ const SecondInnerComponent = () => {
   );
 };
 
-describe('createToastManager', () => {
+describe('ToastManager', () => {
   let rr: RenderResult;
-  let firstToastManager: ToastManager;
-  let secondToastManager: ToastManager;
+  let firstToastManager: ReturnType<typeof createToastManager>;
+  let secondToastManager: ReturnType<typeof createToastManager>;
 
   beforeEach(() => {
     firstToastManager = createToastManager();
@@ -86,6 +89,19 @@ describe('createToastManager', () => {
           </div>
         </secondToastManager.Provider>
       </div>
+    );
+  });
+
+  it('should show toaster using old api', () => {
+    act(() => {
+      firstToastManager(
+        <div data-testid={TestId.Notification}>Some notification</div>
+      );
+      jest.runTimersToTime(0);
+    });
+
+    expect(rr.getByTestId(TestId.Notification).textContent).toContain(
+      'Some notification'
     );
   });
 


### PR DESCRIPTION
- Now it is possible to have several independent instances of toast pub subs
- Added provider which holds toastManager instance and exposes access to it via useToastManager hook

Motivation:
--

From my experience it is good to have an option to create separated instance of pubsub and not to use incapsulated singleton which will be imported all over the project. It helps control entry points of external packages into the project and helps build cleaner and more testable arhitecture.

So I tried to expose creation of the `toastr` singleton and added provider which would allow to consume an instance in more React way down the three. Also it could remove some of the work if there would be a need in redux adapter or smth similar.

P.S. Thank you for this awesome package, I really enjoyed using it!