### PR TITLE
Issue #536 Fixed problem with inline styling of toasts

### DIFF
--- a/src/utils/cssTransition.tsx
+++ b/src/utils/cssTransition.tsx
@@ -82,7 +82,7 @@ export function cssTransition({
       const node = props.nodeRef.current;
       if (node) {
         node.classList.remove(enterClassName);
-        node.style.cssText = '';
+//         node.style.cssText = '';
       }
     };
 


### PR DESCRIPTION
Issue #536 The cssText was being set to ' ' causing all inline styles given to the toast using the ```style``` propoerty in the options to go away. Removing that line fixes the issue and enables using the style option for toasts.

https://github.com/fkhadra/react-toastify/blob/439c60adc6ce8110d2840b3980cc66d1090d9adc/src/utils/cssTransition.tsx#L85

This line ended up removing all inline styles as soon as the toast completed the entering process.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 