### PR TITLE
Fix #572

### DIFF
--- a/scss/_toast.scss
+++ b/scss/_toast.scss
@@ -39,6 +39,7 @@
   &-body {
     margin: auto 0;
     padding: 6px;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Set toast body to 100% width, to allow child elements to consume all available space on older browsers (e.g. IE11). 

Fixes #572