### PR TITLE
Prevent shaking due to 'transform' css when clicking the close button

### DIFF
--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -197,7 +197,6 @@ export function useToast(props: ToastProps) {
         props.closeToast();
         return;
       }
-      toast.style.transition = 'transform 0.2s, opacity 0.2s';
       toast.style.transform = `translate${props.draggableDirection}(0)`;
       toast.style.opacity = '1';
     }

--- a/test/components/Toast.test.tsx
+++ b/test/components/Toast.test.tsx
@@ -392,5 +392,130 @@ describe('Toast Component', () => {
       fireEvent.mouseUp(notification);
       progressBar.isRunning();
     });
+
+    it('Should close when the dragged delta exceeds the removalDistance', () => {
+      const distanceMovedByMouse = 60;
+      const closeToastMockFn = jest.fn();
+      render(
+        <Toast {...REQUIRED_PROPS} closeToast={closeToastMockFn}>
+          FooBar
+        </Toast>
+      );
+      const notification = screen.getByRole('alert').parentElement!;
+      HTMLElement.prototype.getBoundingClientRect = () => {
+        return {
+          top: 50,
+          right: 100,
+          bottom: 100,
+          left: 50
+        } as DOMRect;
+      };
+
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 50
+      });
+
+      fireEvent.mouseDown(notification);
+      fireEvent.mouseMove(notification, {
+        clientX: distanceMovedByMouse,
+        clientY: 50
+      });
+      fireEvent.mouseUp(notification);
+
+      expect(closeToastMockFn).toHaveBeenCalledTimes(1);
+      expect(notification.style.transform).toBe(
+        `translatex(${distanceMovedByMouse}px)`
+      );
+    });
+
+    it('Should return to its original position when the dragged delta does not exceed the removalDistance and not clicked from the close button', () => {
+      const closeToastMockFn = jest.fn();
+      render(
+        <Toast {...REQUIRED_PROPS} closeToast={closeToastMockFn}>
+          FooBar
+        </Toast>
+      );
+      const notification = screen.getByRole('alert').parentElement!;
+      HTMLElement.prototype.getBoundingClientRect = () => {
+        return {
+          top: 50,
+          right: 100,
+          bottom: 100,
+          left: 50
+        } as DOMRect;
+      };
+
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 50
+      });
+
+      fireEvent.mouseDown(notification);
+      fireEvent.mouseMove(notification, {
+        clientX: 39,
+        clientY: 50
+      });
+      fireEvent.mouseUp(notification);
+
+      expect(closeToastMockFn).toHaveBeenCalledTimes(0);
+      expect(notification.style.transform).toBe('translatex(0)');
+      expect(notification.style.opacity).toBe('1');
+    });
+
+    it('Should close when the dragged delta does not exceed the removalDistance and clicked from the close button', () => {
+      const closeToastMockFn = jest.fn();
+
+      const { container } = render(
+        <Toast {...REQUIRED_PROPS} closeToast={closeToastMockFn}>
+          FooBar
+        </Toast>
+      );
+      const closeButton = screen.getByLabelText('close');
+      HTMLElement.prototype.getBoundingClientRect = () => {
+        return {
+          top: 50,
+          right: 100,
+          bottom: 100,
+          left: 50
+        } as DOMRect;
+      };
+
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 50
+      });
+
+      act(() => {
+        fireEvent.mouseDown(closeButton);
+        fireEvent.mouseMove(closeButton, {
+          clientX: 41,
+          clientY: 50
+        });
+        fireEvent.mouseUp(closeButton);
+        fireEvent.click(closeButton);
+      });
+
+      const toastStyle = container.querySelector<HTMLDivElement>(
+        `#${REQUIRED_PROPS.toastId}`
+      )!.style;
+      expect(toastStyle.transform).not.toBe('translatex(0)');
+      expect(toastStyle.opacity).not.toBe('1');
+      expect(closeToastMockFn).toBeCalledTimes(2);
+    });
+
+    it('Should be called the closeToast function when the close button was clicked', () => {
+      const closeToastMockFn = jest.fn();
+
+      render(
+        <Toast {...REQUIRED_PROPS} closeToast={closeToastMockFn}>
+          FooBar
+        </Toast>
+      );
+      const closeButton = screen.getByLabelText('close');
+
+      fireEvent.click(closeButton);
+      expect(closeToastMockFn).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/test/components/ToastContainer.test.tsx
+++ b/test/components/ToastContainer.test.tsx
@@ -6,6 +6,7 @@ import { toast, eventManager, Event } from '../../src/core';
 import { ToastOptions } from '../../src/types';
 
 import { triggerAnimationEnd } from '../helpers';
+import { Slide } from '../../src/components/Transitions';
 
 jest.useFakeTimers();
 
@@ -371,6 +372,28 @@ describe('ToastContainer', () => {
         .getByText('disable')
         .parentElement.getElementsByClassName('Toastify__toast-icon').length
     ).toEqual(0);
+  });
+
+  it('Should not be applied the animation style for drag when the close button was clicked', () => {
+    const toastId = 'testToastId';
+    const { container } = render(<ToastContainer transition={Slide} />);
+
+    act(() => {
+      toast('hello', { toastId });
+      jest.runAllTimers();
+    });
+
+    fireEvent.click(screen.getByLabelText('close'));
+
+    expect(container.querySelector(`#${toastId}`)?.className).toContain(
+      'Toastify__slide-exit'
+    );
+    expect(
+      container.querySelector<HTMLElement>(`#${toastId}`)!.style.transform
+    ).toBeFalsy();
+    expect(
+      container.querySelector<HTMLElement>(`#${toastId}`)!.style.opacity
+    ).toBeFalsy();
   });
 
   describe('Multiple container support', () => {


### PR DESCRIPTION
## Issue

In version 9, `shaking` still occurred when **dragging while clicking the `close button`**.

> This problem occurs prominently in the **safari desktop** environment.

- [Issue new video](https://drive.google.com/file/d/1qAyAVcsCV2jkRm9OpQjJJn01roIaJlPx/view?usp=sharing)
- Normal motion is to slide down and disappear due to the slide effect.

## Solution
- I realized that this was caused by `transform` css.
- Therefore, if it does not exceed the removal range, it is returned to its original position without `transform`.


- [Video after fix bug](https://drive.google.com/file/d/1ytlDUemRlvR-uTUAQNcbJ8qClMBPNC5i/view?usp=sharing)

