### PR TITLE
Fix error in Chrome: remove preventDefault from passive listener

### DIFF
--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -159,8 +159,6 @@ export function useToast(props: ToastProps) {
 
   function onDragMove(e: MouseEvent | TouchEvent) {
     if (drag.canDrag) {
-      e.preventDefault();
-
       const toast = toastRef.current!;
       if (isRunning) pauseToast();
 


### PR DESCRIPTION
This PR stops an error in Chrome: 

`[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See <URL>`

The error is explained at this URL: https://chromestatus.com/feature/5093566007214080