### PR TITLE
make ToastPromiseParams visible to external libraries

### DIFF
--- a/src/core/toast.tsx
+++ b/src/core/toast.tsx
@@ -121,7 +121,7 @@ toast.loading = (content: ToastContent, options?: ToastOptions) =>
     })
   );
 
-interface ToastPromiseParams {
+export interface ToastPromiseParams {
   pending?: string | UpdateOptions;
   success?: string | UpdateOptions;
   error?: string | UpdateOptions;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ export {
   IconProps,
   CloseButtonProps
 } from './components';
-export { toast } from './core';
+export { toast, ToastPromiseParams } from './core';
 export {
   TypeOptions,
   Theme,


### PR DESCRIPTION
`interface ToastPromiseParams` is not visible to external libraries, which causes some typescript error when re-exporting the toast method.