### PR TITLE
Feature: Toast Promise forwarding types

### DIFF
--- a/src/core/toast.tsx
+++ b/src/core/toast.tsx
@@ -115,15 +115,15 @@ toast.loading = (content: ToastContent, options?: ToastOptions) =>
     })
   );
 
-export interface ToastPromiseParams {
-  pending?: string | UpdateOptions;
-  success?: string | UpdateOptions;
-  error?: string | UpdateOptions;
+export interface ToastPromiseParams<T = unknown> {
+  pending?: string | UpdateOptions<void>;
+  success?: string | UpdateOptions<T>;
+  error?: string | UpdateOptions<any>;
 }
 
-function handlePromise<T>(
+function handlePromise<T = unknown>(
   promise: Promise<T> | (() => Promise<T>),
-  { pending, error, success }: ToastPromiseParams,
+  { pending, error, success }: ToastPromiseParams<T>,
   options?: ToastOptions
 ) {
   let id: Id;
@@ -147,7 +147,7 @@ function handlePromise<T>(
 
   const resolver = (
     type: TypeOptions,
-    input: string | UpdateOptions | undefined,
+    input: string | UpdateOptions<T> | undefined,
     result: T
   ) => {
     // Remove the toast if the input has not been provided. This prevents the toast from hanging

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,9 +22,9 @@ export interface ToastContentProps<Data = {}> {
   data?: Data;
 }
 
-export type ToastContent =
+export type ToastContent<T = unknown> =
   | React.ReactNode
-  | ((props: ToastContentProps) => React.ReactNode);
+  | ((props: ToastContentProps<T>) => React.ReactNode);
 
 export type Id = number | string;
 
@@ -231,12 +231,12 @@ export interface ToastOptions<Data = {}> extends CommonOptions {
   data?: Data;
 }
 
-export interface UpdateOptions extends Nullable<ToastOptions> {
+export interface UpdateOptions<T = unknown> extends Nullable<ToastOptions<T>> {
   /**
    * Used to update a toast.
    * Pass any valid ReactNode(string, number, component)
    */
-  render?: ToastContent;
+  render?: ToastContent<T>;
 }
 
 export interface ToastContainerProps extends CommonOptions {


### PR DESCRIPTION
## Issue

When using `toast.promise` the response typing is not being forwarded to the `success: { render({ data }) ... } ` method. That makes difficult if you want the type safety for the render method

## Solution

Following the solution from the issue #700 I forked the project and implemented the type forwarding. Most of the work was done by [midwesterntechnology](https://github.com/midwesterntechnology) at the issue. Aside from that, I just had to guarantee that the error interface at the `resolver` was correct without inferring it as `unkown`.

I played with with playground project nothing is broken, as well as all tests are still working as expected

## Implementation examples with Axios

#### Data is being correctly typed as declared when calling the `axios.get`
<img width="572" alt="Screen Shot 2022-03-01 at 14 36 34" src="https://user-images.githubusercontent.com/41302394/156221482-ff72bbbb-0de7-464d-9a4e-1d48297b9e69.png"> <br />

#### Accessing the object return with autocompletion
<img width="608" alt="Screen Shot 2022-03-01 at 14 36 42" src="https://user-images.githubusercontent.com/41302394/156221375-e72cb345-9637-4ed7-a671-cf9b0ddad61e.png"> <br />

#### Error is being treated as `any` so it would be possible to work is [Type Inference](https://www.typescriptlang.org/docs/handbook/type-inference.html) if needed
<img width="492" alt="Screen Shot 2022-03-01 at 14 36 53" src="https://user-images.githubusercontent.com/41302394/156221378-52e8cfb7-0f2b-420a-90ca-03ff647988b4.png">
