### PR TITLE
Fix closeButton/icon types/rendering

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -70,3 +70,5 @@ export const Icons = {
   error: Error,
   spinner: Spinner
 };
+
+export const maybeIcon = (type: string): type is keyof typeof Icons => type in Icons;

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -67,11 +67,6 @@ export const ToastContainer = forwardRef<HTMLDivElement, ToastContainerProps>(
                       } as StyleHTMLAttributes<HTMLDivElement>
                     }
                     key={`toast-${toastProps.key}`}
-                    closeButton={
-                      toastProps.closeButton === true
-                        ? CloseButton
-                        : toastProps.closeButton
-                    }
                   >
                     {content}
                   </Toast>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CloseButtonProps, IconProps } from '../components';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | null;
@@ -88,9 +89,9 @@ interface CommonOptions {
    * To remove the close button pass `false`
    */
   closeButton?:
-    | React.ReactElement
-    | ((props: any) => React.ReactElement)
-    | boolean;
+    | boolean
+    | ((props: CloseButtonProps) => React.ReactNode)
+    | React.ReactElement<CloseButtonProps>;
 
   /**
    * An optional css class to set for the progress bar.
@@ -169,7 +170,12 @@ interface CommonOptions {
    * Used to display a custom icon. Set it to `false` to prevent
    * the icons from being displayed
    */
-  icon?: React.ReactNode | false;
+  icon?:
+    | boolean
+    | ((props: IconProps) => React.ReactNode)
+    | React.ReactElement<IconProps>
+    | string
+    | number;
 
   /**
    * Theme to use.


### PR DESCRIPTION
* Allow render numbers as icon
* Pass closeButton from ToastContainer to Toast as-is
* Fix icon types
* Fix closeButton types