### PR TITLE
Add queueLimit property to ToastContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ $ yarn add react-toastify
 - Possibility to update a toast
 - You can control the progress bar a la `nprogress` 😲
 - You can limit the number of toast displayed at the same time
+- You can limit the length of the toast queue
 - Dark mode 🌒
 - And much more !
 

--- a/example/components/App.tsx
+++ b/example/components/App.tsx
@@ -39,6 +39,7 @@ class App extends React.Component {
       progress: '',
       disableAutoClose: false,
       limit: 0,
+      queueLimit: undefined,
       theme: 'light'
     };
   }
@@ -102,7 +103,7 @@ class App extends React.Component {
   handleRadioOrSelect = e =>
     this.setState({
       [e.target.name]:
-        e.target.name === 'limit'
+        e.target.name === 'limit' || 'queueLimit'
           ? parseInt(e.target.value, 10)
           : e.target.value
     });
@@ -164,15 +165,17 @@ class App extends React.Component {
               <div className="options_wrapper">
                 <label htmlFor="autoClose">
                   Delay
-                  <input
-                    type="number"
-                    name="autoClose"
-                    id="autoClose"
-                    value={(this.state.autoClose as unknown) as string}
-                    onChange={this.handleAutoCloseDelay}
-                    disabled={this.state.disableAutoClose}
-                  />
-                  ms
+                  <div className="input_suffix">
+                    <input
+                      type="number"
+                      name="autoClose"
+                      id="autoClose"
+                      value={this.state.autoClose as unknown as string}
+                      onChange={this.handleAutoCloseDelay}
+                      disabled={this.state.disableAutoClose}
+                    />
+                    ms
+                  </div>
                 </label>
                 <label htmlFor="transition">
                   Transition
@@ -221,6 +224,16 @@ class App extends React.Component {
                     name="limit"
                     id="limit"
                     value={this.state.limit}
+                    onChange={this.handleRadioOrSelect}
+                  />
+                </label>
+                <label htmlFor="queueLimit">
+                  Queue Limit
+                  <input
+                    type="number"
+                    name="queueLimit"
+                    id="queueLimit"
+                    value={this.state.queueLimit}
                     onChange={this.handleRadioOrSelect}
                   />
                 </label>

--- a/example/components/ContainerCode.tsx
+++ b/example/components/ContainerCode.tsx
@@ -24,6 +24,7 @@ export const ContainerCode: React.FC<ContainerCodeProps> = ({
   disableAutoClose,
   autoClose,
   hideProgressBar,
+  queueLimit,
   newestOnTop,
   closeOnClick,
   pauseOnHover,
@@ -53,6 +54,12 @@ export const ContainerCode: React.FC<ContainerCodeProps> = ({
         {`={${disableAutoClose ? false : autoClose}}`}
       </div>
       {!disableAutoClose ? getProp('hideProgressBar', hideProgressBar) : ''}
+      {queueLimit !== undefined ? (
+        <div>
+          <span className="code__props">queueLimit</span>
+          {`={${queueLimit}}`}
+        </div>
+      ) : null}
       {getProp('newestOnTop', newestOnTop)}
       {getProp('closeOnClick', closeOnClick)}
       {getProp('rtl', rtl)}

--- a/example/index.css
+++ b/example/index.css
@@ -101,8 +101,9 @@ select {
   grid-template-columns: repeat(2, 1fr);
 }
 
-.container__options div:last-child {
-  grid-column: 1 / -1;
+.input_suffix {
+  display: flex;
+  align-items: center;
 }
 
 .container__actions {

--- a/src/hooks/useToastContainer.ts
+++ b/src/hooks/useToastContainer.ts
@@ -252,6 +252,14 @@ export function useToastContainer(props: ToastContainerProps) {
       instance.count > props.limit &&
       isNotAnUpdate
     ) {
+      if (
+        instance.props.queueLimit !== undefined &&
+        instance.count - props.limit > instance.props.queueLimit
+      ) {
+        instance.count--;
+        return;
+      }
+
       instance.queue.push({ toastContent, toastProps, staleId });
     } else if (isNum(delay)) {
       setTimeout(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -283,6 +283,11 @@ export interface ToastContainerProps extends CommonOptions {
    * Limit the number of toast displayed at the same time
    */
   limit?: number;
+
+  /**
+   * Limit the length of the toast queue
+   */
+  queueLimit?: number;
 }
 
 export interface ToastTransitionProps {

--- a/test/components/ToastContainer.test.tsx
+++ b/test/components/ToastContainer.test.tsx
@@ -566,4 +566,85 @@ describe('ToastContainer', () => {
       expect(screen.queryByText('toast-3')).toBe(null);
     });
   });
+
+  describe('Limit queue lenght', () => {
+    it('Should not crash when using queueLimit', () => {
+      render(<ToastContainer queueLimit={1} />);
+
+      act(() => {
+        toast('Hello');
+        jest.runAllTimers();
+      });
+
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+
+    it('Should not work witout limit parametr', () => {
+      render(<ToastContainer queueLimit={1} />);
+
+      act(() => {
+        toast('toast-1');
+        toast('toast-2');
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('toast-1')).toBeInTheDocument();
+      expect(screen.queryByText('toast-2')).toBeInTheDocument();
+    });
+
+    it('Should disable queue when param is 0', () => {
+      render(<ToastContainer limit={1} queueLimit={0} />);
+
+      act(() => {
+        toast('toast-1');
+        toast('toast-2');
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('toast-1')).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(screen.getByLabelText('close'));
+        jest.runAllTimers();
+      });
+
+      triggerAnimationEnd(screen.getByText('toast-1'));
+
+      expect(screen.queryByText('toast-2')).not.toBeInTheDocument();
+    });
+
+    it('Should limit queue length', () => {
+      render(<ToastContainer autoClose={500} limit={1} queueLimit={1} />);
+
+      act(() => {
+        toast('toast-1', { toastId: 'toast-1' });
+        toast('toast-2', { toastId: 'toast-2' });
+        toast('toast-3', { toastId: 'toast-3' });
+        jest.runAllTimers();
+      });
+
+      expect(screen.queryByText('toast-1')).toBeInTheDocument();
+      expect(screen.queryByText('toast-2')).not.toBeInTheDocument();
+      expect(screen.queryByText('toast-3')).not.toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(screen.getByLabelText('close'));
+        jest.runAllTimers();
+      });
+
+      triggerAnimationEnd(screen.getByText('toast-1'));
+
+      expect(screen.queryByText('toast-2')).toBeInTheDocument();
+      expect(screen.queryByText('toast-3')).not.toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(screen.getByLabelText('close'));
+        jest.runAllTimers();
+      });
+
+      triggerAnimationEnd(screen.getByText('toast-2'));
+
+      expect(screen.queryByText('toast-3')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
Hi, I was working on the feature mentioned in "Limit the waiting queue to 2 toasts" #640  and here are my effects 😀
I hope you will like my implementation of this property.

My implementation seems to me to meet all the needs written in this discussion, as we can limit the queue length if we have a limit set, and disable the queue if we set the property to 0.
By default, the property is undefied, so as it was, nothing will change for current react-toastify users.

For this feature I also wrote corresponding tests, but I am not a specialist in this topic and I will be happy to improve or add tests, because you certainly have a much greater authority on this topic.

I also edited the playground to be able to specify queueLimit in it, unfortunately I also had to delicately modify the css to fit the new property 😀

In the course of work, I also figured out that it might be a good idea to add a toast property "includeInQueue", for toasts that aren't important. Please let me know what you think about this idea, if I get approval, I will be happy to work on it as well.