### PR TITLE
Add update toast type when toast promise resolves

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -83,6 +83,7 @@ export const Toast: React.FC<ToastProps> = props => {
         {...eventHandlers}
         style={style}
         ref={toastRef}
+        data-testid={type}
       >
         <div
           {...(isIn && { role: role })}

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -99,10 +99,15 @@ toast.loading = (content: ToastContent, options?: ToastOptions) =>
     })
   );
 
+interface ToastPromiseUpdateOptions<T = unknown>
+  extends Omit<UpdateOptions<T>, 'type'> {
+  type?: TypeOptions | ((data: T) => TypeOptions);
+}
+
 export interface ToastPromiseParams<T = unknown> {
-  pending?: string | UpdateOptions<void>;
-  success?: string | UpdateOptions<T>;
-  error?: string | UpdateOptions<any>;
+  pending?: string | ToastPromiseUpdateOptions<void>;
+  success?: string | ToastPromiseUpdateOptions<T>;
+  error?: string | ToastPromiseUpdateOptions<any>;
 }
 
 function handlePromise<T = unknown>(
@@ -132,7 +137,7 @@ function handlePromise<T = unknown>(
 
   const resolver = (
     type: TypeOptions,
-    input: string | UpdateOptions<T> | undefined,
+    input: string | ToastPromiseUpdateOptions<T> | undefined,
     result: T
   ) => {
     // Remove the toast if the input has not been provided. This prevents the toast from hanging
@@ -148,7 +153,9 @@ function handlePromise<T = unknown>(
       ...options,
       data: result
     };
-    const params = isStr(input) ? { render: input } : input;
+    const params = isStr(input)
+      ? { render: input }
+      : { ...input, type: isFn(input.type) ? input.type(result) : input.type };
 
     // if the id is set we know that it's an update
     if (id) {

--- a/src/hooks/useToastContainer.ts
+++ b/src/hooks/useToastContainer.ts
@@ -76,10 +76,10 @@ export function useToastContainer(props: ToastContainerProps) {
       .on(Event.ClearWaitingQueue, clearWaitingQueue)
       .emit(Event.DidMount, instance);
 
-      return () => {
-        toastToRender.clear();
-        eventManager.emit(Event.WillUnmount, instance);
-      };
+    return () => {
+      toastToRender.clear();
+      eventManager.emit(Event.WillUnmount, instance);
+    };
   }, []);
 
   useEffect(() => {

--- a/test/core/toast.test.tsx
+++ b/test/core/toast.test.tsx
@@ -482,11 +482,10 @@ describe('toastify', () => {
   it('should update the toast type when the promise resolves', async () => {
     render(<ToastContainer />);
 
-    const promiseResolved = jest.fn(() => Promise.resolve());
-    const promiseRejected = jest.fn(() => Promise.reject());
+    const promise = jest.fn(() => Promise.resolve());
 
     act(() => {
-      toast.promise(promiseResolved, {
+      toast.promise(promise, {
         success: {
           render: 'success',
           type: () => 'error'
@@ -495,18 +494,10 @@ describe('toastify', () => {
           render: 'error',
         }
       });
-      toast.promise(promiseRejected, {
-        success: 'success',
-        error: {
-          render: 'error',
-          type: () => 'success'
-        }
-      });
     });
 
     await waitFor(() => {
       expect(screen.getByTestId('error')).not.toBe(null);
-      expect(screen.getByTestId('success')).not.toBe(null);
     });
   });
 });

--- a/test/core/toast.test.tsx
+++ b/test/core/toast.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, act, screen } from '@testing-library/react';
+import { render, act, screen, waitFor } from '@testing-library/react';
 
 import { triggerAnimationEnd } from '../helpers';
 import { eventManager, toast, Event } from '../../src/core';
@@ -477,5 +477,36 @@ describe('toastify', () => {
     triggerAnimationEnd(screen.getByText('hello'));
 
     expect(screen.queryByText('hello')).toBe(null);
+  });
+
+  it('should update the toast type when the promise resolves', async () => {
+    render(<ToastContainer />);
+
+    const promiseResolved = jest.fn(() => Promise.resolve());
+    const promiseRejected = jest.fn(() => Promise.reject());
+
+    act(() => {
+      toast.promise(promiseResolved, {
+        success: {
+          render: 'success',
+          type: () => 'error'
+        },
+        error: {
+          render: 'error',
+        }
+      });
+      toast.promise(promiseRejected, {
+        success: 'success',
+        error: {
+          render: 'error',
+          type: () => 'success'
+        }
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error')).not.toBe(null);
+      expect(screen.getByTestId('success')).not.toBe(null);
+    });
   });
 });


### PR DESCRIPTION
Now the `type` prop accepts a function and receives the data returned from the promise. It's similar to the `render` prop.

example:
```ts
const promise = () => Promise.resolve({ errors: 'error' });

toast.promise(promise, {
  success: {
    render: ({ data }) => data.errors ? 'Promise rejected' : 'Promise resolved',
    type: (data) => data.errors ? 'error' : 'success',
  },
  error: 'Promise rejected'
});
```

There's no need to work around using `toast.update` anymore if the promise resolves with an error.