### PR TITLE
(chore): change type prop to optional

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -23,7 +23,7 @@ export interface ProgressBarProps {
   /**
    * Optional type : info, success ...
    */
-  type: TypeOptions;
+  type?: TypeOptions;
 
   /**
    * The theme that is currently used


### PR DESCRIPTION
`type` prop needs to be set as optional in types as it has a default value set.

I stumbled upon this when i opened tests for ProgressBar, they showed missing `type` prop