### PR TITLE
Move `types` condition to the front of the `addons/use-notification-center` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,9 +160,9 @@
     "./package.json": "./package.json",
     "./scss/": "./scss/",
     "./addons/use-notification-center": {
+      "types": "./addons/use-notification-center/index.d.ts",
       "require": "./addons/use-notification-center/index.js",
-      "import": "./addons/use-notification-center/index.esm.mjs",
-      "types": "./addons/use-notification-center/index.d.ts"
+      "import": "./addons/use-notification-center/index.esm.mjs"
     }
   }
 }


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

This matches how `types` were already configured for the rest of your entrypoints, this one was the single outlier