### PR TITLE
CloseButton type definition is wrong

### DIFF
--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -13,7 +13,7 @@ export function CloseButton({
   closeToast,
   theme,
   ariaLabel = 'close'
-}: CloseButtonProps) {
+}: CloseButtonProps): JSX.Element {
   return (
     <button
       className={`${Default.CSS_NAMESPACE}__close-button ${Default.CSS_NAMESPACE}__close-button--${theme}`}

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -13,12 +13,12 @@ export function CloseButton({
   closeToast,
   theme,
   ariaLabel = 'close'
-}: CloseButtonProps): JSX.Element {
+}: CloseButtonProps): React.ReactElement {
   return (
     <button
       className={`${Default.CSS_NAMESPACE}__close-button ${Default.CSS_NAMESPACE}__close-button--${theme}`}
       type="button"
-      onClick={e => {
+      onClick={(e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
         closeToast(e);
       }}

--- a/test/components/CloseButton.test.tsx
+++ b/test/components/CloseButton.test.tsx
@@ -7,10 +7,12 @@ const closeToast = jest.fn();
 
 describe('CloseButton', () => {
   it('Should call closeToast on click', () => {
-    render(
+    const { container } = render(
       <CloseButton closeToast={closeToast} type="default" theme="light" />
     );
+    const element = container.firstChild;
 
+    expect(element instanceof HTMLButtonElement).toBe(true);
     expect(closeToast).not.toHaveBeenCalled();
     fireEvent.click(screen.getByLabelText('close'));
     expect(closeToast).toHaveBeenCalled();


### PR DESCRIPTION
Fix for issue #971 
**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 