### PR TITLE
Update clsx to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "clsx": "^1.1.1"
+    "clsx": "^2.1.0"
   },
   "main": "dist/react-toastify.js",
   "module": "dist/react-toastify.esm.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2996,10 +2996,10 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
A 2.0 release was made because https://github.com/lukeed/clsx/pull/57 was considered a breaking change

https://github.com/lukeed/clsx/releases/tag/v2.0.0