### PR TITLE
fix: replace useLayoutEffect into useIsomorphicLayoutEffect for server side rendering

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,8 +1,9 @@
 import cx from 'clsx';
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { toast } from '../core';
 import { useToastContainer } from '../hooks/useToastContainer';
+import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
 import { ToastContainerProps, ToastPosition } from '../types';
 import { Default, Direction, isFn, parseClassName } from '../utils';
 import { Toast } from './Toast';
@@ -56,7 +57,7 @@ export function ToastContainer(props: ToastContainerProps) {
     }
   }
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (stacked) {
       const nodes = containerRef.current!.querySelectorAll('[data-in="true"]');
       const gap = 12;

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
This PR will fix the following issue when running on server side.

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

The `useIsomorphicLayoutEffect` hook fixes this problem by switching between useEffect and useLayoutEffect following the execution environment.