### PR TITLE
Update react and react-dom peer dependencies to only allow >=18

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "extract-pkg": "tar xzvf react-toastify.tgz -C node_modules/react-toastify --strip-components 1 && rimraf react-toastify.tgz"
   },
   "peerDependencies": {
-    "react": ">=16",
-    "react-dom": ">=16"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "prettier": {
     "printWidth": 80,


### PR DESCRIPTION
This will prevent users from installing the latest version of react-toastify if they're using an unsupported version of React.
I reckon this is the better option vs just getting "useSyncExternalStore is not a function" after installation.