### PR TITLE
Updated wrong format used error with bounce in ToastContainer.tsx

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -10,8 +10,8 @@ import { Toast } from './Toast';
 import { Bounce } from './Transitions';
 
 export const defaultProps: ToastContainerProps = {
+  transition= 'Bounce',
   position: 'top-right',
-  transition: Bounce,
   autoClose: 5000,
   closeButton: true,
   pauseOnHover: true,


### PR DESCRIPTION
In ToastContainer.tsx Updated wrong format used with bounce error solved by removing colon used previously and add equals symbol which is correct and solved the problem of wrong format in the code.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/fkhadra/react-toastify) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`).
5. Run `yarn start` to test your changes in the playground.
6. Update the readme is needed
7. Update the typescript definition is needed
8. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier-all`).
9. Make sure your code lints (`yarn lint:fix`).

**Learn more about contributing [here](https://github.com/fkhadra/react-toastify/blob/master/CONTRIBUTING.md)** 