### PR TITLE
Fix clear all bug when promise has neither a pending nor a success/error

### DIFF
--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -123,7 +123,7 @@ function handlePromise<TData = unknown, TError = unknown, TPending = unknown>(
     // Remove the toast if the input has not been provided. This prevents the toast from hanging
     // in the pending state if a success/error toast has not been provided.
     if (input == null) {
-      toast.dismiss(id);
+      if (id) toast.dismiss(id);
       return;
     }
 


### PR DESCRIPTION
On resolving a promise, if there is no success/error, then the pending toast needs to be dismissed. But if there was no pending toast, then toast.dismiss() is being called with undefined, which clears all toast. It should only call toast.dimiss() if id exists for the pending toast.