### PR TITLE
Feature/Added prop for passing function when close button is clicked

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -41,7 +41,8 @@ export const Toast: React.FC<ToastProps> = props => {
     isIn,
     isLoading,
     closeOnClick,
-    theme
+    theme,
+    onButtonClose 
   } = props;
   const defaultClassName = cx(
     `${Default.CSS_NAMESPACE}__toast`,
@@ -65,7 +66,14 @@ export const Toast: React.FC<ToastProps> = props => {
   const icon = getIcon(props);
   const isProgressControlled = !!progress || !autoClose;
 
-  const closeButtonProps = { closeToast, type, theme };
+  const handleButtonClose = () => {
+    if (onButtonClose) {
+      onButtonClose();
+    }
+    closeToast();
+  };
+
+  const closeButtonProps = { closeToast: handleButtonClose, type, theme };
   let Close: React.ReactNode = null;
 
   if (closeButton === false) {

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -123,6 +123,7 @@ export function ToastContainer(props: ToastContainerProps) {
                     toastProps.containerId
                   )}
                   style={toastProps.style}
+                  onButtonClose={toastProps.onButtonClose} 
                   key={`toast-${toastProps.key}`}
                 >
                   {content}

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,6 +315,7 @@ export interface ToastProps extends ToastOptions {
   type: TypeOptions;
   collapseAll: () => void;
   stacked?: boolean;
+  onButtonClose?: () => void;
 }
 
 /**


### PR DESCRIPTION
# Fixes
Fixes #1117 

## Summary
Added an `onButtonClose` prop to the `Toast` component to allow users to define a callback function that gets called when the close button of a toast is clicked. This enhancement improves the flexibility and usability of the toast component by allowing custom behavior to be executed when the close button is pressed.

## Changes
- Updated the `Toast` component to accept and handle a new `onButtonClose` prop.
- Updated the `ToastContainer` component to pass the `onButtonClose` prop to each `Toast` component.
- Updated TypeScript definitions to include the new `onButtonClose` prop.

## Checklist
- [x] Forked the repository and created a new branch from master.
- [x] Ran `yarn` in the repository root.
- [x] Added tests to cover the new functionality.
- [x] Ensured the test suite passes (`yarn test`).
- [x] Ran `yarn start` to test changes in the playground.
- [x] Updated the readme if needed.
- [x] Updated the TypeScript definitions if needed.
- [x] Formatted the code with prettier (`yarn prettier-all`).
- [x] Ensured the code lints (`yarn lint:fix`).

## Additional Information
This feature allows users to pass a callback function that will be called when the toast's close button is clicked, enabling more custom and dynamic behaviors when a toast is dismissed.
