### PR TITLE
fix: Remove toasts from the waiting queue if they are dismissed.

### DIFF
--- a/playground/src/components/App.tsx
+++ b/playground/src/components/App.tsx
@@ -22,7 +22,7 @@ window.toast = toast;
 
 class App extends React.Component {
   state = App.getDefaultState();
-  toastId: Id;
+  toastId: Id = -1;
   resolvePromise = true;
 
   static getDefaultState() {
@@ -41,6 +41,11 @@ class App extends React.Component {
     this.setState({
       ...App.getDefaultState()
     });
+
+  clearLast = () => {
+    toast.dismiss(this.toastId);
+    this.toastId = -1;
+  };
 
   clearAll = () => toast.dismiss();
 
@@ -227,6 +232,11 @@ class App extends React.Component {
               <li>
                 <button className="btn" onClick={this.updateToast}>
                   Update
+                </button>
+              </li>
+              <li>
+                <button className="btn" onClick={this.clearLast}>
+                  Clear Last
                 </button>
               </li>
               <li>

--- a/src/core/containerObserver.ts
+++ b/src/core/containerObserver.ts
@@ -61,7 +61,7 @@ export function createContainerObserver(
       const t = toasts.get(id);
       if (t) markAsRemoved(t);
       const countBefore = queue.length;
-      queue = queue.filter(t => id !== t.props.toastId);
+      queue = queue.filter(entry => id !== entry.props.toastId);
       toastCount -= countBefore - queue.length;
     }
     notify();

--- a/src/core/containerObserver.ts
+++ b/src/core/containerObserver.ts
@@ -60,6 +60,9 @@ export function createContainerObserver(
     } else {
       const t = toasts.get(id);
       if (t) markAsRemoved(t);
+      const countBefore = queue.length;
+      queue = queue.filter(t => id !== t.props.toastId);
+      toastCount -= countBefore - queue.length;
     }
     notify();
   };


### PR DESCRIPTION
## Context
Currently, if a toast is dismissed, it will be removed from the view if active. However, if the `ToastContainer` is configured with a limit, excess toasts are added to an internal queue that will serve overflow toasts when active toasts are dismissed or time out. Toasts in this queue can be cleared via `toast.clearWaitingQueue()`, but this will empty the queue entirely. It is not currently possible to remove a toast from the waiting queue by ID.

## Changes
This change augments the existing `toast.dismiss(id)` function by not only dismissing the toast if active, but also removing any pending activity for a toast by that ID from the waiting queue. This feels appropriate, as someone explicitly dismissing a toast probably wants it gone, regardless of if it's currently active or waiting to be made active.

## Links
#1233 