### PR TITLE
feat: Add isFocusable to ToastOptions

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -33,7 +33,8 @@ export const Toast: React.FC<ToastProps> = props => {
     isLoading,
     closeOnClick,
     theme,
-    ariaLabel
+    ariaLabel,
+    isFocusable
   } = props;
   const defaultClassName = cx(
     `${Default.CSS_NAMESPACE}__toast`,
@@ -81,7 +82,7 @@ export const Toast: React.FC<ToastProps> = props => {
     >
       <div
         id={toastId as string}
-        tabIndex={0}
+        tabIndex={isFocusable !== false ? 0 : -1}
         onClick={onClick}
         data-in={isIn}
         className={cssClasses}

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,12 @@ export interface ToastOptions<Data = unknown> extends CommonOptions {
   delay?: number;
 
   isLoading?: boolean;
+
+  /**
+   * If true, the toast will be focusable.
+   * Default: true
+   */
+  isFocusable?: boolean;
 }
 
 export interface UpdateOptions<T = unknown> extends Nullable<ToastOptions<T>> {


### PR DESCRIPTION
## Context
Currently, toasts will always be focusable, as they unconditionally set `tabIndex` to `0`. If toasts have focusable elements inside them, it can be desirable to set the toast itself as unfocusable and enable focus on the contained elements (buttons, links, etc.) as well as the close box.

## Changes
This change adds an optional boolean property to `ToastOptions`, `isFocusable`. If it is set to `true` (or is missing) then the toast will  be focusable, as per existing behavior. If set to `false` then the toast will not be focusable.
