### PR TITLE
fix(types): restrict toast role prop to valid ARIA roles

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -121,7 +121,7 @@ interface CommonOptions {
    * `Default: alert`
    *  https://www.w3.org/WAI/PF/aria/roles
    */
-  role?: string;
+  role?: 'alert' | 'status' | 'log';
 
   /**
    * Set id to handle multiple container


### PR DESCRIPTION
This PR restricts the `role` prop in the `ToastOptions` interface to only allow valid ARIA roles: `'alert' | 'status' | 'log'`.

✅ Improves accessibility.
✅ Enforces valid types via TypeScript.

Fixes: #1243

