### PR TITLE
Fix: Restore textAlign functionality via ToastContainer prop

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -34,7 +34,7 @@ export function ToastContainer(props: ToastContainerProps) {
   const [collapsed, setIsCollapsed] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const { getToastToRender, isToastActive, count } = useToastContainer(containerProps);
-  const { className, style, rtl, containerId, hotKeys } = containerProps;
+  const { className, style, toastStyle, rtl, containerId, hotKeys } = containerProps;
 
   function getClassName(position: ToastPosition) {
     const defaultClassName = cx(
@@ -136,14 +136,15 @@ export function ToastContainer(props: ToastContainerProps) {
             tabIndex={-1}
             className={getClassName(position)}
             data-stacked={stacked}
-            style={containerStyle}
             key={`c-${position}`}
+            style={containerStyle}
           >
             {toastList.map(({ content, props: toastProps }) => {
               return (
                 <Toast
                   {...toastProps}
                   stacked={stacked}
+                  style={toastStyle}
                   collapseAll={collapseAll}
                   isIn={isToastActive(toastProps.toastId, toastProps.containerId)}
                   key={`t-${toastProps.key}`}


### PR DESCRIPTION
Description:
Fixes #1244

This pull request resolves a regression where the textAlign style was not being applied to toast notifications. The original issue (#657) was reintroduced in a recent version, making it impossible to globally set text alignment for all toasts.

The fix ensures that style properties are correctly applied. For textAlign to work as expected, the toast element must be a block-level element. Therefore, the correct way to implement this is by applying a global toastStyle prop to the ToastContainer.

## Changes Made
Ensured that custom styles passed via the toastStyle prop on ToastContainer are correctly applied to every toast it renders.

Updated the approach for text alignment to rely on this global prop for more consistent and predictable CSS behavior.

## New Usage for Global Text Alignment
To properly align the text for all toasts rendered by a container, you must now use the toastStyle prop on the <ToastContainer> component itself. You need to set both display: "block" and the desired textAlign value in the style object.

Example Code:

JavaScript

import React from 'react';
import { ToastContainer, toast } from 'react-toastify';
import 'react-toastify/dist/ReactToastify.css';

function App() {
  // The toast call is now simple, with no style options.
  const showToast = () => {
    toast("This text is now properly centered!");
  };

  return (
    <div>
      <button onClick={showToast}>Show Centered Toast</button>
      
      {/* The toastStyle prop is now set on the container to apply
        the style to all toasts rendered by it.
      */}
      <ToastContainer 
        toastStyle={{
          display: "block",
          textAlign: "center",
        }}
      />
    </div>
  );
}
This approach provides a reliable way to globally control text alignment for all toasts within a specific container.