### PR TITLE
Add ARIA Labels and tests

### DIFF
--- a/src/components/ProgressBar.cy.tsx
+++ b/src/components/ProgressBar.cy.tsx
@@ -90,4 +90,40 @@ describe('ProgressBar', () => {
 
     cy.findByRole('progressbar').should('have.attr', 'style').and('include', 'scaleX(0.7)');
   });
+
+  it('should have ARIA attributes when controlled progress is used', () => {
+    cy.mount(
+      <Wrapper>
+        <ProgressBar {...getProps()} controlledProgress progress={0.7} />
+      </Wrapper>
+    );
+
+    cy.findByRole('progressbar')
+      .should('have.attr', 'aria-valuenow', '70')
+      .and('have.attr', 'aria-valuemin', '0')
+      .and('have.attr', 'aria-valuemax', '100');
+  });
+
+  it('should convert progress values correctly to percentage', () => {
+    cy.mount(
+      <Wrapper>
+        <ProgressBar {...getProps()} controlledProgress progress={0.35} />
+      </Wrapper>
+    );
+
+    cy.findByRole('progressbar')
+      .should('have.attr', 'aria-valuenow', '35');
+  });
+
+  it('should handle string progress values', () => {
+    cy.mount(
+      <Wrapper>
+        <ProgressBar {...getProps()} controlledProgress progress="0.85" />
+      </Wrapper>
+    );
+
+    cy.findByRole('progressbar')
+      .should('have.attr', 'aria-valuenow', '85');
+  });
+
 });

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -112,7 +112,11 @@ export function ProgressBar({
           }
   };
 
-  // TODO: add aria-valuenow, aria-valuemax, aria-valuemin
+  const shouldShowAria = controlledProgress && progress !== undefined;
+  const progressValue = shouldShowAria ? (typeof progress === 'number' ? progress : parseFloat(progress || '0')) : 0;
+  const ariaValueNow = Math.min(100, Math.max(0, Math.round(progressValue * 100)));
+  const ariaValueMin = 0;
+  const ariaValueMax = 100;
 
   return (
     <div className={`${Default.CSS_NAMESPACE}__progress-bar--wrp`} data-hidden={isHidden}>
@@ -122,7 +126,12 @@ export function ProgressBar({
       <div
         role="progressbar"
         aria-hidden={isHidden ? 'true' : 'false'}
-        aria-label="notification timer"
+        aria-label={'Notification progress bar: ' + ariaValueNow + ' percent'}
+        {...(shouldShowAria && {
+          'aria-valuenow': ariaValueNow,
+          'aria-valuemin': ariaValueMin,
+          'aria-valuemax': ariaValueMax
+        })}
         className={classNames}
         style={style}
         {...animationEvent}


### PR DESCRIPTION
This PR solves issue #1259

The ARIA labels are edited in a way voice assistant can read the ARIA labels and read the progress value when is sent as prop. 