### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check the [documentation](https://fkhadra.github.io/react-toastify/introduction)
 - You can control the progress bar a la `nprogress` 😲
 - You can limit the number of toast displayed at the same time
 - Dark mode 🌒
-- Pause timer programmaticaly 
+- Pause timer programmatically 
 - Stacked notifications!
 - And much more !
 


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.