### PR TITLE
fix(types): narrow ToastTransitionProps.position to ToastPosition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -290,7 +290,7 @@ export interface ToastContainerProps extends CommonOptions, Pick<HTMLAttributes<
 export interface ToastTransitionProps {
   isIn: boolean;
   done: () => void;
-  position: ToastPosition | string;
+  position: ToastPosition;
   preventExitTransition: boolean;
   nodeRef: React.RefObject<HTMLElement | null>;
   children?: React.ReactNode;


### PR DESCRIPTION
## Describe the bug

Closes #1288.

`ToastTransitionProps.position` is typed `ToastPosition | string`. Because TypeScript subsumes `'top-right' | … | string` into plain `string`, this **widens the union away** and consumers of `ToastTransitionProps` (anyone authoring a custom transition) lose all type-safety and autocomplete on `position`.

Every other declaration of the same value uses the closed union:

```ts
// src/types.ts
interface CommonOptions  { position?: ToastPosition; }   // line 76
interface ToastProps     { position: ToastPosition; }    // line 310
interface ToastTransitionProps { position: ToastPosition | string; } // line 293 — the outlier
```

**Why `| string` is incorrect, not just imprecise**

1. A transition builds its animation class by concatenation — `const enterClassName = appendPosition ? \`\${enter}--\${position}\` : enter` (`src/utils/cssTransition.tsx`) — and the shipped CSS only defines rules for the six known positions (`.Toastify__bounce-enter--top-left`, `--top-right`, …). Any other string yields a class like `Toastify__bounce-enter--whatever` that matches no rule → **no animation** (silent breakage).
2. The `position` handed to a transition always originates from `ToastProps.position` (`<Transition position={position} … />` in `src/components/Toast.tsx`, where `Toast` is `React.FC<ToastProps>`), which is `ToastPosition`. So the `| string` arm is never legitimately reachable through normal use.

## Fix

```diff
 export interface ToastTransitionProps {
   isIn: boolean;
   done: () => void;
-  position: ToastPosition | string;
+  position: ToastPosition;
```

One line — consistent with `CommonOptions.position` / `ToastProps.position` and with what the runtime actually supports. Restores typo-safety and autocomplete for custom-transition authors.

## Verification

- A type-level probe asserting `ToastTransitionProps['position']` is exactly `ToastPosition` (and that the value is assignable back to `ToastPosition`) **fails on `main`** (`TS2322: Type 'true' is not assignable to type 'false'` + `TS2322: Type 'string' is not assignable to type 'ToastPosition'`) and **passes with this change**.
- `pnpm build` (tsup + dts) succeeds; the generated `dist/index.d.ts` now shows `ToastTransitionProps.position: ToastPosition`, matching the rest of the surface.
- `pnpm prettier --check src/types.ts` clean.

No runtime code changes.