### PR TITLE
fix: prevent duplicate toast announcements

### DIFF
--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -122,9 +122,6 @@ export function ToastContainer(props: ToastContainerProps) {
         }
       }}
       onMouseLeave={collapseAll}
-      aria-live="polite"
-      aria-atomic="false"
-      aria-relevant="additions text"
       aria-label={containerProps['aria-label']}
     >
       {getToastToRender((position, toastList) => {

--- a/src/tests.cy.tsx
+++ b/src/tests.cy.tsx
@@ -62,3 +62,11 @@ it('focus notification when alt+t is pressed', () => {
   cy.get('body').type('{alt+t}');
   cy.focused().should('have.attr', 'role', 'alert').and('have.attr', 'aria-label', 'notification');
 });
+
+it('does not nest toast live regions', () => {
+  cy.mount(<ToastContainer autoClose={false} />);
+
+  toast('hello');
+
+  cy.findByRole('alert').parents('[aria-live]').should('not.exist');
+});


### PR DESCRIPTION
## Summary

- remove the redundant live-region attributes from `ToastContainer`
- keep each toast's configurable `role` as the single announcement source
- add a regression test that prevents toast live regions from being nested

Fixes #1291

## Why

`ToastContainer` used `aria-live="polite"` while each toast defaults to
`role="alert"`. Since `alert` is itself a live region, this nested live-region
structure caused NVDA to announce the same toast multiple times and announce it
again when it was removed.

Removing the container's live-region attributes avoids the duplicate
announcements without changing toast roles, custom role overrides, the
container's accessible label, or keyboard navigation.

## Test plan

- [x] `pnpm build`
- [x] `pnpm exec prettier --check src/components/ToastContainer.tsx src/tests.cy.tsx`
- [x] `pnpm exec cypress run --component -b chrome --spec 'src/**/*.cy.tsx,packages/**/*.cy.tsx'` (70 passing, 7 existing pending)
- [x] Playground: verified one `role="alert"` toast with no `aria-live` ancestor
