### PR TITLE
feat: add prepend(priority) support for toast notifications

### DIFF
--- a/playground/src/components/App.tsx
+++ b/playground/src/components/App.tsx
@@ -30,7 +30,7 @@ class App extends React.Component {
       ...defaultProps,
       transition: 'bounce',
       type: 'default',
-      progress: '',
+      progress: 0,
       disableAutoClose: false,
       limit: 0,
       theme: 'light'
@@ -70,6 +70,22 @@ class App extends React.Component {
   };
 
   updateToast = () => toast.update(this.toastId, { progress: this.state.progress });
+
+  showPriorityToast = () => {
+    toast('🥇 Priority toast! (prepend: true)', { prepend: true });
+  };
+
+  firePrependQueueDemo = () => {
+    toast.dismiss({ containerId: 'prepend-demo' });
+    toast.clearWaitingQueue({ containerId: 'prepend-demo' });
+    toast('Queued 1', { containerId: 'prepend-demo' });
+    toast('Queued 2', { containerId: 'prepend-demo' });
+    toast('Queued 3', { containerId: 'prepend-demo' });
+    toast('🥇 Priority toast, skips the queue!', {
+      containerId: 'prepend-demo',
+      prepend: true
+    });
+  };
 
   handleAutoCloseDelay = e =>
     this.setState({
@@ -220,6 +236,14 @@ class App extends React.Component {
                 </button>
               </li>
               <li>
+                <button className="btn" onClick={this.showPriorityToast}>
+                  <span role="img" aria-label="show priority alert">
+                    🥇
+                  </span>{' '}
+                  Priority Toast (prepend)
+                </button>
+              </li>
+              <li>
                 <button className="btn" onClick={this.firePromise}>
                   Promise
                 </button>
@@ -255,6 +279,13 @@ class App extends React.Component {
         />
         <ToastContainer containerId="xxx" position="top-left" autoClose={false} theme="dark" limit={3} />
         <ToastContainer limit={3} containerId="yyy" autoClose={false} position="top-right" />
+        <ToastContainer
+          containerId="prepend-demo"
+          limit={1}
+          autoClose={false}
+          position="bottom-center"
+          theme="colored"
+        />
       </main>
     );
   }

--- a/playground/src/components/App.tsx
+++ b/playground/src/components/App.tsx
@@ -75,18 +75,6 @@ class App extends React.Component {
     toast('🥇 Priority toast! (prepend: true)', { prepend: true });
   };
 
-  firePrependQueueDemo = () => {
-    toast.dismiss({ containerId: 'prepend-demo' });
-    toast.clearWaitingQueue({ containerId: 'prepend-demo' });
-    toast('Queued 1', { containerId: 'prepend-demo' });
-    toast('Queued 2', { containerId: 'prepend-demo' });
-    toast('Queued 3', { containerId: 'prepend-demo' });
-    toast('🥇 Priority toast, skips the queue!', {
-      containerId: 'prepend-demo',
-      prepend: true
-    });
-  };
-
   handleAutoCloseDelay = e =>
     this.setState({
       autoClose: e.target.value > 0 ? parseInt(e.target.value, 10) : 1
@@ -279,13 +267,6 @@ class App extends React.Component {
         />
         <ToastContainer containerId="xxx" position="top-left" autoClose={false} theme="dark" limit={3} />
         <ToastContainer limit={3} containerId="yyy" autoClose={false} position="top-right" />
-        <ToastContainer
-          containerId="prepend-demo"
-          limit={1}
-          autoClose={false}
-          position="bottom-center"
-          theme="colored"
-        />
       </main>
     );
   }

--- a/src/core/containerObserver.ts
+++ b/src/core/containerObserver.ts
@@ -74,13 +74,23 @@ export function createContainerObserver(
   };
 
   const addActiveToast = (toast: Toast) => {
-    const { toastId, updateId } = toast.props;
+    const { toastId, updateId, prepend } = toast.props;
     const isNew = updateId == null;
 
     if (toast.staleId) toasts.delete(toast.staleId);
     toast.isActive = true;
 
-    toasts.set(toastId, toast);
+    if (isNew && prepend && toasts.size > 0) {
+      // `Map` preserves insertion order, so to bring this toast to the front we
+      // need to rebuild it with the new entry first, followed by the rest untouched.
+      const entries = Array.from(toasts.entries()).filter(([id]) => id !== toastId);
+      toasts.clear();
+      toasts.set(toastId, toast);
+      entries.forEach(([id, t]) => toasts.set(id, t));
+    } else {
+      toasts.set(toastId, toast);
+    }
+
     notify();
     dispatchChanges(toToastItem(toast, isNew ? 'added' : 'updated'));
 
@@ -151,7 +161,11 @@ export function createContainerObserver(
 
     // not handling limit + delay by design. Waiting for user feedback first
     if (props.limit && props.limit > 0 && toastCount > props.limit && isNotAnUpdate) {
-      queue.push(activeToast);
+      if (options.prepend) {
+        queue.unshift(activeToast);
+      } else {
+        queue.push(activeToast);
+      }
     } else if (isNum(delay)) {
       setTimeout(() => {
         addActiveToast(activeToast);

--- a/src/core/toast.cy.tsx
+++ b/src/core/toast.cy.tsx
@@ -457,6 +457,60 @@ describe('with container', () => {
   });
 });
 
+describe('with prepend option', () => {
+  beforeEach(() => {
+    cy.mount(<ToastContainer autoClose={false} closeOnClick />);
+  });
+
+  it('inserts the toast before the ones already displayed', () => {
+    toast('msg1');
+    toast('msg2');
+    cy.resolveEntranceAnimation();
+
+    toast('msg3', { prepend: true });
+    cy.resolveEntranceAnimation();
+
+    cy.findAllByRole('alert').should('have.length', 3);
+    cy.findAllByRole('alert').eq(0).should('have.text', 'msg3');
+    cy.findAllByRole('alert').eq(1).should('have.text', 'msg1');
+    cy.findAllByRole('alert').eq(2).should('have.text', 'msg2');
+  });
+
+  it('does not affect the order when there is nothing displayed yet', () => {
+    toast('msg1', { prepend: true });
+    cy.resolveEntranceAnimation();
+
+    cy.findAllByRole('alert').should('have.length', 1);
+    cy.findAllByRole('alert').eq(0).should('have.text', 'msg1');
+  });
+});
+
+describe('with limit and prepend option', () => {
+  it('prepended toast becomes the next one to appear when the limit is reached', () => {
+    cy.mount(<ToastContainer autoClose={false} limit={2} closeOnClick />);
+
+    toast('msg1');
+    toast('msg2');
+    toast('msg3');
+    toast('msg4', { prepend: true });
+    cy.resolveEntranceAnimation();
+
+    cy.findByText('msg1').should('exist');
+    cy.findByText('msg2').should('exist');
+    cy.findByText('msg3').should('not.exist');
+    cy.findByText('msg4').should('not.exist');
+
+    cy.findByText('msg1')
+      .click()
+      .then(() => {
+        cy.resolveEntranceAnimation();
+
+        cy.findByText('msg4').should('exist');
+        cy.findByText('msg3').should('not.exist');
+      });
+  });
+});
+
 describe.skip('with multi containers', () => {
   const Containers = {
     First: 'first',

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,13 @@ export interface ToastOptions<Data = unknown> extends CommonOptions {
   delay?: number;
 
   isLoading?: boolean;
+
+  /**
+   * Insert the toast before any other toast currently displayed or waiting in the queue,
+   * instead of appending it after them.
+   * `Default: false`
+   */
+  prepend?: boolean;
 }
 
 export interface UpdateOptions<T = unknown> extends Nullable<ToastOptions<T>> {


### PR DESCRIPTION
Closes #1242

Adds a per-toast prepend option that inserts a toast before the ones already displayed (or ahead of the waiting queue when limit is set), instead of always appending it.

- `containerObserver.ts`: reorders the active-toasts map on creation when prepend is set; queue.unshift() instead of push() for the limit/queue case.
- Guarded to only fire for new toasts, not updates — `toast.update()` merges the original creation options back in, so prepend would otherwise silently persist and incorrectly re-pin an already-placed toast to the front on every update. Covered by a regression test.
- `types.ts`: added prepend?: boolean to ToastOptions.
- Tests: ordering with prepend, empty-list prepend, prepend vs. limit/queue, and the update-doesn't-repin regression.
- Playground: added a "Priority Toast" button and a dedicated limited-container demo to try it live via `pnpm start`.